### PR TITLE
Fix Sonar project name escaping in workflow

### DIFF
--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -45,7 +45,7 @@ jobs:
           args: >
             -Dsonar.projectKey=burgan-tech_vnext-schema
             -Dsonar.organization=burgan-tech
-            -Dsonar.projectName="vNext Schema Definitions"
+            -Dsonar.projectName=vNext\ Schema\ Definitions
             -Dsonar.projectVersion=1.0.0
             -Dsonar.sources=index.js,schemas
             -Dsonar.tests=test


### PR DESCRIPTION
Updated the SonarCloud analysis step to escape spaces in the project name argument, ensuring correct parsing by the command line.

## Summary by Sourcery

CI:
- Escape spaces in the SonarCloud projectName argument in the GitHub Actions workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarCloud scan configuration to standardize project name handling, improving reliability and consistency of code quality reports in CI.
  * Ensures scans run consistently across environments and avoids parsing issues with project names containing spaces.
  * No user-facing impact; UI and functionality remain unchanged.
  * No changes to APIs or exported/public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->