### PR TITLE
Remove sonar.projectName from SonarQube config

### DIFF
--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -45,7 +45,6 @@ jobs:
           args: >
             -Dsonar.projectKey=burgan-tech_vnext-schema
             -Dsonar.organization=burgan-tech
-            -Dsonar.projectName=vNext\ Schema\ Definitions
             -Dsonar.projectVersion=1.0.0
             -Dsonar.sources=index.js,schemas
             -Dsonar.tests=test


### PR DESCRIPTION
The sonar.projectName property was removed from the SonarQube analysis step in the GitHub Actions workflow. This may be to rely on the default project name or to simplify configuration.

## Summary by Sourcery

CI:
- Remove sonar.projectName property from the SonarQube config in the CI workflow