### PR TITLE
Trigger SonarQube analysis on pull requests

### DIFF
--- a/.github/workflows/check-sonar.yml
+++ b/.github/workflows/check-sonar.yml
@@ -1,9 +1,8 @@
 name: SonarQube Analysis
 on:
-  push:
-    branches:
-      - master
-      - 'release-v*'
+  pull_request:
+    branches: [ master, 'release-v*']
+    types: [opened, synchronize, reopened]
       
 jobs:
   sonarcloud:


### PR DESCRIPTION
Updated the workflow to run SonarQube analysis on pull request events for master and release branches, instead of on push. This ensures code is analyzed before merging.

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to trigger SonarQube analysis on pull_request (opened, synchronize, reopened) for master and release branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal quality checks to run on pull requests targeting primary and release branches, including when PRs are opened, updated, or reopened. The underlying workflow steps are unchanged.
  * This update affects the development pipeline only; there are no changes to application features, behavior, performance, or UI. No action is required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->