### PR TITLE
Refactor subFlow and timer schema definitions

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -315,36 +315,120 @@
       }
     },
     "subFlow": {
-      "type": "object",
-      "required": [
-        "type",
-        "process",
-        "mapping"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "description": "SubFlow type",
-          "enum": [
-            "C",
-            "F",
-            "S",
-            "P"
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "process"
           ],
-          "enumDescriptions": [
-            "Core",
-            "Flow",
-            "SubFlow",
-            "Sub Process"
-          ]
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "S",
+                "P"
+              ],
+              "description": "SubFlow type. S=SubFlow, P=SubProcess",
+              "maxLength": 10
+            },
+            "process": {
+              "type": "object",
+              "properties": {
+                "key": {
+                  "type": "string",
+                  "description": "Key value of the referenced record (readable identifier)",
+                  "pattern": "^[a-zA-Z0-9\\-]+$",
+                  "maxLength": 255
+                },
+                "domain": {
+                  "type": "string",
+                  "description": "Domain where the referenced record is located (required for cross-domain references)",
+                  "pattern": "^[a-zA-Z\\-]+$",
+                  "maxLength": 100,
+                  "examples": [
+                    "core",
+                    "idm",
+                    "banking",
+                    "payment"
+                  ]
+                },
+                "flow": {
+                  "type": "string",
+                  "description": "Flow name where the referenced record is located",
+                  "pattern": "^[a-z\\-]+$",
+                  "maxLength": 100
+                },
+                "version": {
+                  "type": "string",
+                  "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                  "description": "Version information of the referenced record (semantic versioning MAJOR.MINOR.PATCH format)",
+                  "maxLength": 50
+                }
+              },
+              "required": [
+                "key",
+                "domain",
+                "flow",
+                "version"
+              ],
+              "additionalProperties": false,
+              "examples": [
+                {
+                  "key": "user-authentication-workflow",
+                  "domain": "idm",
+                  "flow": "user-authentication",
+                  "version": "1.0.0"
+                },
+                {
+                  "key": "user-login-state",
+                  "domain": "core",
+                  "flow": "authentication",
+                  "version": "2.1.0"
+                },
+                {
+                  "key": "payment-validation-task",
+                  "domain": "banking",
+                  "flow": "payment-process",
+                  "version": "1.2.3"
+                }
+              ],
+              "description": "SubFlow process reference"
+            },
+            "mapping": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "required": [
+                    "code",
+                    "location"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "description": "SubFlow mapping code"
+                    },
+                    "location": {
+                      "type": "string",
+                      "description": "Location of the mapping code file"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Mapping definition for data exchange with SubFlow"
+            }
+          },
+          "additionalProperties": false
         },
-        "process": {
-          "$ref": "#/definitions/reference"
-        },
-        "mapping": {
-          "$ref": "#/definitions/scriptCode"
+        {
+          "type": "null"
         }
-      }
+      ],
+      "description": "Information about the sub-workflow to be called for SubFlow state type. Can be null if developer does not have a subflow definition."
     },
     "onExecuteTask": {
       "type": "object",
@@ -427,12 +511,28 @@
         "timer": {
           "anyOf": [
             {
-              "$ref": "#/definitions/timerConfig"
+              "type": "object",
+              "required": [
+                "code",
+                "location"
+              ],
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Timer rule code"
+                },
+                "location": {
+                  "type": "string",
+                  "description": "Location of the code file"
+                }
+              },
+              "additionalProperties": false
             },
             {
               "type": "null"
             }
-          ]
+          ],
+          "description": "Timer information if the transition should execute automatically"
         },
         "labels": {
           "type": "array",


### PR DESCRIPTION
Updated the 'subFlow' property to support more detailed object structure and allow null values, including stricter validation for process references and mapping definitions. Refactored 'timer' property to use an inline object schema for code and location, also allowing null, improving clarity and validation for workflow definitions.

## Summary by Sourcery

Refactor subFlow and timer properties in the workflow definition schema to improve validation, support null values, and clarify object structures

Enhancements:
- Allow subFlow to be null and enforce stricter validation for process references and mapping definitions
- Convert timer to an inline object schema with code and location fields and allow null values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - SubFlow is now optional (nullable) with richer, inline process details and optional mapping.
  - Transition timers can be configured inline or set to null, with descriptive guidance.
- Refactor
  - Streamlined schema by inlining process and timer configurations for clearer validation and usage.
- Documentation
  - Updated descriptions to clarify SubFlow usage, allowed types, and timer behavior.
- Style
  - Consistent constraints and examples added to improve readability and consumer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->