### PR TITLE
Update scope property to use string enum values

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -62,29 +62,17 @@
             ],
             "properties": {
                 "scope": {
-                    "type": "integer",
+                    "type": "string",
                     "description": "Function scope (TaskScope enum value)",
-                    "oneOf": [
-                        {
-                            "const": 1,
-                            "description": "State OnEntry scope"
-                        },
-                        {
-                            "const": 2,
-                            "description": "State OnExit scope"
-                        },
-                        {
-                            "const": 3,
-                            "description": "Transition OnExecute scope"
-                        },
-                        {
-                            "const": 4,
-                            "description": "Workflow OnStart scope"
-                        },
-                        {
-                            "const": 5,
-                            "description": "Workflow OnEnd scope"
-                        }
+                    "enum": [
+                        "D",
+                        "F",
+                        "I"
+                    ],
+                    "enumDescriptions": [
+                        "Domain",
+                        "Flow",
+                        "Instance"
                     ]
                 },
                 "task": {


### PR DESCRIPTION
Changed the 'scope' property in function-definition.schema.json from integer enum values to string enum values ('D', 'F', 'I') to better represent the TaskScope options.

## Summary by Sourcery

Enhancements:
- Replace numeric scope enums with string values ('D','F','I') to reflect TaskScope options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated function definition schema: scope changed from numeric constants to a string enum with values "D", "F", "I".
  - Validation now expects string values for scope instead of integers.

- Documentation
  - Added clear enum descriptions for scope values: Domain, Flow, and Instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->