### PR TITLE
Remove 'mapping' from required attributes in schema

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -57,8 +57,7 @@
             "description": "Function definition attributes",
             "required": [
                 "scope",
-                "task",
-                "mapping"
+                "task"
             ],
             "properties": {
                 "scope": {


### PR DESCRIPTION
The 'mapping' property is no longer required in the function definition schema. This change updates the required fields to reflect the current schema requirements.

## Summary by Sourcery

Enhancements:
- Remove "mapping" from the list of required fields in function-definition.schema.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function definitions are now more flexible: the “mapping” attribute is optional. Only “scope” and “task” are required. This simplifies creating and importing definitions that don’t need mappings, improves compatibility with varied workflows, and reduces validation errors for configurations that omit “mapping.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->