### PR TITLE
Extension and loadData property for View

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -157,6 +157,33 @@
     }
   },
   "definitions": {
+    "viewDefinition": {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "extensions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "loadData": {
+              "type": "boolean"
+            },
+            "view": {
+              "$ref": "#/definitions/reference"
+            }
+          },
+          "required": [
+            "view"
+          ]
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "versionStrategy": {
       "type": "string",
       "enum": [
@@ -539,14 +566,7 @@
               }
             },
             "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/reference"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+                  "$ref": "#/definitions/viewDefinition"
             },
             "onExecutionTasks": {
               "type": "array",
@@ -771,14 +791,7 @@
               }
             },
             "view": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/reference"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/definitions/viewDefinition"
             },
             "onExecutionTasks": {
               "type": "array",


### PR DESCRIPTION
as viewDefinition

## Summary by Sourcery

Include extension and loadData properties in the View section of the workflow-definition JSON schema

Enhancements:
- Add optional "extension" property to View definitions
- Add optional "loadData" property to View definitions