### PR TITLE
feat: add support for $self target in shared transitions

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -382,9 +382,18 @@
           "pattern": "^[a-z0-9-]+$"
         },
         "target": {
-          "type": "string",
-          "description": "Target state key",
-          "pattern": "^[a-z0-9-]+$"
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Target state key",
+              "pattern": "^[a-z0-9-]+$"
+            },
+            {
+              "type": "string",
+              "const": "$self",
+              "description": "Special marker for self-transition in shared transitions"
+            }
+          ]
         },
         "from": {
           "type": "string",


### PR DESCRIPTION
- Modified target property to accept either normal state key or special $self marker
- $self resolves to the source state for each state in availableIn
- Enables self-referencing shared transitions

## Summary by Sourcery

Add support for the $self target in shared transitions by extending the target property and updating the workflow definition schema.

New Features:
- Allow transition definitions to specify $self as the target state
- Resolve $self to the source state for each state listed in availableIn, enabling self-referencing shared transitions

Enhancements:
- Update workflow-definition.schema.json to accept either a normal state key or the $self marker for the target property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow transitions now support self-transitions, enabling states to transition to themselves in shared transitions for more flexible workflow definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->