### PR TITLE
Update schemas for view and workflow definitions

### DIFF
--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -57,7 +57,6 @@
             "description": "View definition attributes",
             "required": [
                 "type",
-                "target",
                 "content"
             ],
             "properties": {
@@ -76,24 +75,6 @@
                         {
                             "const": 3,
                             "description": "Markdown content type"
-                        }
-                    ]
-                },
-                "target": {
-                    "type": "integer",
-                    "description": "View target workflow component type",
-                    "oneOf": [
-                        {
-                            "const": 1,
-                            "description": "State targeted view"
-                        },
-                        {
-                            "const": 2,
-                            "description": "Transition targeted view"
-                        },
-                        {
-                            "const": 3,
-                            "description": "Task targeted view"
                         }
                     ]
                 },
@@ -170,25 +151,25 @@
                                             "properties": {
                                                 "type": {
                                                     "type": "integer",
-                                                    "description": "Android ortamda override edilecek View ın  içerik türü",
+                                                    "description": "Content type of the View to be overridden in Android environment",
                                                     "oneOf": [
                                                         {
                                                             "const": 1,
-                                                            "description": "Json içerik türü"
+                                                            "description": "JSON content type"
                                                         },
                                                         {
                                                             "const": 2,
-                                                            "description": "Html içerik türü"
+                                                            "description": "HTML content type"
                                                         },
                                                         {
                                                             "const": 3,
-                                                            "description": "Markdown içerik türü"
+                                                            "description": "Markdown content type"
                                                         }
                                                     ]
                                                 },
                                                 "content": {
                                                     "type": "string",
-                                                    "description": "Android ortamda override edilecek View'in içeriği. Json, Html veya Markdown formatında olabilir.",
+                                                    "description": "Content of the View to be overridden in Android environment. Can be in JSON, HTML or Markdown format.",
                                                     "pattern": "^[a-zA-Z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -200,7 +181,7 @@
                                                 },
                                                 "display": {
                                                     "type": "string",
-                                                    "description": "View'in display tipi.",
+                                                    "description": "Display type of the View.",
                                                     "pattern": "^[a-z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -233,7 +214,7 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "description": "Android ortamda override edilecek View"
+                                    "description": "View to be overridden in Android environment"
                                 },
                                 "ios": {
                                     "anyOf": [
@@ -242,25 +223,25 @@
                                             "properties": {
                                                 "type": {
                                                     "type": "integer",
-                                                    "description": "Ios ortamda override edilecek View ın  içerik türü",
+                                                    "description": "Content type of the View to be overridden in iOS environment",
                                                     "oneOf": [
                                                         {
                                                             "const": 1,
-                                                            "description": "Json içerik türü"
+                                                            "description": "JSON content type"
                                                         },
                                                         {
                                                             "const": 2,
-                                                            "description": "Html içerik türü"
+                                                            "description": "HTML content type"
                                                         },
                                                         {
                                                             "const": 3,
-                                                            "description": "Markdown içerik türü"
+                                                            "description": "Markdown content type"
                                                         }
                                                     ]
                                                 },
                                                 "content": {
                                                     "type": "string",
-                                                    "description": "Ios ortamda override edilecek View'in içeriği. Json, Html veya Markdown formatında olabilir.",
+                                                    "description": "Content of the View to be overridden in iOS environment. Can be in JSON, HTML or Markdown format.",
                                                     "pattern": "^[a-zA-Z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -272,7 +253,7 @@
                                                 },
                                                 "display": {
                                                     "type": "string",
-                                                    "description": "View'in display tipi.",
+                                                    "description": "Display type of the View.",
                                                     "pattern": "^[a-z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -305,7 +286,7 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "description": "Ios ortamda override edilecek View"
+                                    "description": "View to be overridden in iOS environment"
                                 },
                                 "web": {
                                     "anyOf": [
@@ -314,25 +295,25 @@
                                             "properties": {
                                                 "type": {
                                                     "type": "integer",
-                                                    "description": "Web ortamda override edilecek View ın  içerik türü",
+                                                    "description": "Content type of the View to be overridden in Web environment",
                                                     "oneOf": [
                                                         {
                                                             "const": 1,
-                                                            "description": "Json içerik türü"
+                                                            "description": "JSON content type"
                                                         },
                                                         {
                                                             "const": 2,
-                                                            "description": "Html içerik türü"
+                                                            "description": "HTML content type"
                                                         },
                                                         {
                                                             "const": 3,
-                                                            "description": "Markdown içerik türü"
+                                                            "description": "Markdown content type"
                                                         }
                                                     ]
                                                 },
                                                 "content": {
                                                     "type": "string",
-                                                    "description": "Web ortamda override edilecek View'in içeriği. Json, Html veya Markdown formatında olabilir.",
+                                                    "description": "Content of the View to be overridden in Web environment. Can be in JSON, HTML or Markdown format.",
                                                     "pattern": "^[a-zA-Z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -344,7 +325,7 @@
                                                 },
                                                 "display": {
                                                     "type": "string",
-                                                    "description": "View'in display tipi.",
+                                                    "description": "Display type of the View.",
                                                     "pattern": "^[a-z\\-]+$",
                                                     "maxLength": 100,
                                                     "examples": [
@@ -377,7 +358,7 @@
                                             "type": "null"
                                         }
                                     ],
-                                    "description": "Web ortamda override edilecek View"
+                                    "description": "View to be overridden in Web environment"
                                 }
                             },
                             "additionalProperties": false
@@ -386,7 +367,7 @@
                             "type": "null"
                         }
                     ],
-                    "description": "Platform bazında override edilecek view lar"
+                    "description": "Views to be overridden on a platform basis"
                 }
             },
             "additionalProperties": false

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -349,7 +349,8 @@
           "type": "object",
           "required": [
             "type",
-            "process"
+            "process",
+            "mapping"
           ],
           "properties": {
             "type": {
@@ -362,93 +363,21 @@
               "maxLength": 10
             },
             "process": {
-              "type": "object",
-              "properties": {
-                "key": {
-                  "type": "string",
-                  "description": "Key value of the referenced record (readable identifier)",
-                  "pattern": "^[a-zA-Z0-9\\-]+$",
-                  "maxLength": 255
-                },
-                "domain": {
-                  "type": "string",
-                  "description": "Domain where the referenced record is located (required for cross-domain references)",
-                  "pattern": "^[a-zA-Z\\-]+$",
-                  "maxLength": 100,
-                  "examples": [
-                    "core",
-                    "idm",
-                    "banking",
-                    "payment"
-                  ]
-                },
-                "flow": {
-                  "type": "string",
-                  "description": "Flow name where the referenced record is located",
-                  "pattern": "^[a-z\\-]+$",
-                  "maxLength": 100
-                },
-                "version": {
-                  "type": "string",
-                  "pattern": "^\\d+\\.\\d+\\.\\d+$",
-                  "description": "Version information of the referenced record (semantic versioning MAJOR.MINOR.PATCH format)",
-                  "maxLength": 50
-                }
-              },
-              "required": [
-                "key",
-                "domain",
-                "flow",
-                "version"
-              ],
-              "additionalProperties": false,
-              "examples": [
-                {
-                  "key": "user-authentication-workflow",
-                  "domain": "idm",
-                  "flow": "user-authentication",
-                  "version": "1.0.0"
-                },
-                {
-                  "key": "user-login-state",
-                  "domain": "core",
-                  "flow": "authentication",
-                  "version": "2.1.0"
-                },
-                {
-                  "key": "payment-validation-task",
-                  "domain": "banking",
-                  "flow": "payment-process",
-                  "version": "1.2.3"
-                }
-              ],
+              "$ref": "#/definitions/reference",
               "description": "SubFlow process reference"
             },
             "mapping": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "required": [
-                    "code",
-                    "location"
-                  ],
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "SubFlow mapping code"
-                    },
-                    "location": {
-                      "type": "string",
-                      "description": "Location of the mapping code file"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
+              "$ref": "#/definitions/scriptCode"
+            },
+            "viewOverrides": {
+              "type": "object",
+              "description": "Dictionary of view overrides for subflow views. Key is the original view key, value is the reference to the new view definition.",
+              "patternProperties": {
+                "^[a-zA-Z0-9\\-]+$": {
+                  "$ref": "#/definitions/reference"
                 }
-              ],
-              "description": "Mapping definition for data exchange with SubFlow"
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Removed the 'target' property from view-definition.schema.json and updated property descriptions to English for platform-specific overrides. In workflow-definition.schema.json, made 'mapping' required, refactored 'process' and 'mapping' to use shared definitions, and added a 'viewOverrides' property for subflow view customization.

## Summary by Sourcery

Update JSON schemas for view and workflow definitions to align property requirements, remove obsolete fields, standardize descriptions, and introduce viewOverrides

New Features:
- Add viewOverrides property to workflow-definition schema for subflow view customization.

Enhancements:
- Remove deprecated target property from view-definition schema and translate platform-specific override descriptions to English.
- Require mapping in workflow-definition schema and refactor process and mapping to reference shared definitions.