### PR TITLE
Update 'view' property schema reference

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1009,14 +1009,7 @@
           }
         },
         "view": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/reference"
-            },
-            {
-              "type": "null"
-            }
-          ]
+           "$ref": "#/definitions/viewDefinition"
         },
         "subFlow": {
           "anyOf": [


### PR DESCRIPTION
Changed the 'view' property in workflow-definition.schema.json to reference 'viewDefinition' instead of allowing a reference or null. This enforces stricter schema validation for workflow definitions.

## Summary by Sourcery

Update view property schema reference to enforce stricter validation of workflow definitions

Enhancements:
- Restrict the "view" property to reference "viewDefinition" only
- Remove allowance for null or external references on the "view" property

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized workflow definition schema structure for improved maintainability. Existing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->