### PR TITLE
Update view reference in workflow schema

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -658,7 +658,7 @@
               "view": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/reference"
+                    "$ref": "#/definitions/viewDefinition"
                   },
                   {
                     "type": "null"


### PR DESCRIPTION
Changed the 'view' property reference from 'reference' to 'viewDefinition' in workflow-definition.schema.json to ensure correct schema validation.

## Summary by Sourcery

Enhancements:
- Correct 'view' property reference in workflow schema from 'reference' to 'viewDefinition'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated workflow definition schema to enforce stricter validation requirements for view properties in workflow transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->