### PR TITLE
Add 'mapping' property to workflow schema transitions

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -553,6 +553,17 @@
               "items": {
                 "$ref": "#/definitions/onExecuteTask"
               }
+            },
+            "mapping": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/scriptCode"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Input mapping for the transition"
             }
           }
         },
@@ -577,6 +588,9 @@
                 "type": "null"
               },
               "view": {
+                "type": "null"
+              },
+              "mapping": {
                 "type": "null"
               }
             }
@@ -618,6 +632,9 @@
                 "type": "null"
               },
               "view": {
+                "type": "null"
+              },
+              "mapping": {
                 "type": "null"
               }
             }
@@ -778,6 +795,17 @@
               "items": {
                 "$ref": "#/definitions/onExecuteTask"
               }
+            },
+            "mapping": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/scriptCode"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Input mapping for the transition"
             }
           }
         },
@@ -802,6 +830,9 @@
                 "type": "null"
               },
               "view": {
+                "type": "null"
+              },
+              "mapping": {
                 "type": "null"
               }
             }
@@ -843,6 +874,9 @@
                 "type": "null"
               },
               "view": {
+                "type": "null"
+              },
+              "mapping": {
                 "type": "null"
               }
             }
@@ -953,6 +987,17 @@
           "items": {
             "$ref": "#/definitions/onExecuteTask"
           }
+        },
+        "mapping": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/scriptCode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Input mapping for the transition"
         },
         "schema": {
           "anyOf": [


### PR DESCRIPTION
Introduces a 'mapping' property to various transition definitions in the workflow-definition.schema.json. The new property allows for input mapping using either a scriptCode reference or null, providing greater flexibility in transition configuration.

## Summary by Sourcery

Introduce a new “mapping” property to workflow transition definitions in the schema to support input mapping via a scriptCode reference or null.

New Features:
- Add a “mapping” field to various transition definitions in workflow-definition.schema.json to enable input mapping
- Allow mapping values to be specified as either a scriptCode reference or null