### PR TITLE
155 hotfix add header mapping support in daprservicetask

### DIFF
--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -123,6 +123,10 @@
                                             "PATCH"
                                         ],
                                         "description": "HTTP method"
+                                    },
+                                    "body": {
+                                        "type": "object",
+                                        "description": "Service call body"
                                     }
                                 },
                                 "required": [
@@ -467,7 +471,7 @@
                         "additionalProperties": false
                     }
                 },
-                 {
+                {
                     "if": {
                         "properties": {
                             "type": {


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Support mapping HTTP headers in DaprServiceTask by extending the task definition schema