### PR TITLE
$self keyword as shared transitions target

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -712,8 +712,8 @@
             },
             "target": {
               "type": "string",
-              "description": "Target state key",
-              "pattern": "^[a-z0-9-]+$"
+              "description": "Target state key. Can be a state key or special keyword like $self",
+              "pattern": "^(\\$self|[a-z0-9-]+)$"
             },
             "from": {
               "type": "string",


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow using "$self" as a target in shared transitions within the workflow-definition schema