### PR TITLE
Unify mapping code schema and add encoding option

### DIFF
--- a/schemas/core-schema.schema.json
+++ b/schemas/core-schema.schema.json
@@ -306,21 +306,34 @@
         },
         "mappingReference": {
             "type": "object",
+            "required": [
+                "code"
+            ],
             "properties": {
-                "location": {
-                    "type": "string",
-                    "pattern": "^\\./.+\\.csx$"
-                },
-                "code": {
-                    "type": "string"
-                }
-                ,
                 "type": {
                     "type": "string",
-                    "enum": [
-                        "G",
-                        "L"
-                    ]
+                    "enum": ["G", "L"],
+                    "enumDescriptions": [
+                        "Global",
+                        "Local"
+                    ],
+                    "default": "L",
+                    "description": "Mapping type - Global or Local"
+                },
+                "location": {
+                    "type": "string",
+                    "pattern": "^\\./.+\\.csx$",
+                    "description": "Code file location"
+                },
+                "code": {
+                    "type": "string",
+                    "description": "Mapping code content"
+                },
+                "encoding": {
+                    "type": "string",
+                    "description": "Code encoding format",
+                    "enum": ["B64", "NAT"],
+                    "default": "B64"
                 }
             }
         }

--- a/schemas/extension-definition.schema.json
+++ b/schemas/extension-definition.schema.json
@@ -173,10 +173,19 @@
                             "type": "object",
                             "description": "Extension mapping code",
                             "required": [
-                                "location",
                                 "code"
                             ],
                             "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["G", "L"],
+                                    "enumDescriptions": [
+                                        "Global",
+                                        "Local"
+                                    ],
+                                    "default": "L",
+                                    "description": "Mapping type - Global or Local"
+                                },
                                 "location": {
                                     "type": "string",
                                     "description": "Code file location",
@@ -186,6 +195,12 @@
                                     "type": "string",
                                     "description": "Mapping code content",
                                     "minLength": 1
+                                },
+                                "encoding": {
+                                    "type": "string",
+                                    "description": "Code encoding format",
+                                    "enum": ["B64", "NAT"],
+                                    "default": "B64"
                                 }
                             },
                             "additionalProperties": false

--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -150,10 +150,19 @@
                             "type": "object",
                             "description": "Function mapping code",
                             "required": [
-                                "location",
                                 "code"
                             ],
                             "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["G", "L"],
+                                    "enumDescriptions": [
+                                        "Global",
+                                        "Local"
+                                    ],
+                                    "default": "L",
+                                    "description": "Mapping type - Global or Local"
+                                },
                                 "location": {
                                     "type": "string",
                                     "description": "Code file location",
@@ -163,6 +172,12 @@
                                     "type": "string",
                                     "description": "Mapping code content",
                                     "minLength": 1
+                                },
+                                "encoding": {
+                                    "type": "string",
+                                    "description": "Code encoding format",
+                                    "enum": ["B64", "NAT"],
+                                    "default": "B64"
                                 }
                             },
                             "additionalProperties": false

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -363,71 +363,37 @@
       ]
     },
     "scriptCode": {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "const": "G",
-              "description": "Global mapping - code and location not required"
-            },
-            "code": {
-              "type": "string",
-              "description": "Script code content"
-            },
-            "location": {
-              "type": "string",
-              "description": "Location of the script file"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "properties": {
-            "type": {
-              "oneOf": [
-                {
-                  "const": "L",
-                  "description": "Local mapping - code and location is required"
-                }
-              ],
-              "description": "Task type"
-            },
-            "code": {
-              "type": "string",
-              "description": "Script code content"
-            },
-            "location": {
-              "type": "string",
-              "description": "Location of the script file"
-            }
-          },
-          "required": [
-            "code",
-            "location"
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["G", "L"],
+          "enumDescriptions": [
+            "Global",
+            "Local"
           ],
-          "additionalProperties": false
+          "default": "L",
+          "description": "Script type - Global or Local"
         },
-        {
-          "type": "object",
-          "properties": {
-            "code": {
-              "type": "string",
-              "description": "Script code content"
-            },
-            "location": {
-              "type": "string",
-              "description": "Location of the script file"
-            }
-          },
-          "required": [
-            "code",
-            "location"
-          ],
-          "additionalProperties": false
+        "code": {
+          "type": "string",
+          "description": "Script code content"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the script file"
+        },
+        "encoding": {
+          "type": "string",
+          "description": "Code encoding format",
+          "enum": ["B64", "NAT"],
+          "default": "B64"
         }
-      ]
+      },
+      "required": [
+        "code"
+      ],
+      "additionalProperties": false
     },
     "subFlow": {
       "anyOf": [
@@ -558,22 +524,7 @@
             "timer": {
               "anyOf": [
                 {
-                  "type": "object",
-                  "required": [
-                    "code",
-                    "location"
-                  ],
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "Timer rule code"
-                    },
-                    "location": {
-                      "type": "string",
-                      "description": "Location of the code file"
-                    }
-                  },
-                  "additionalProperties": false
+                  "$ref": "#/definitions/scriptCode"
                 },
                 {
                   "type": "null"
@@ -652,22 +603,7 @@
             "required": ["timer"],
             "properties": {
               "timer": {
-                "type": "object",
-                "required": [
-                  "code",
-                  "location"
-                ],
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "Timer rule code"
-                  },
-                  "location": {
-                    "type": "string",
-                    "description": "Location of the code file"
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/definitions/scriptCode"
               },
               "rule": {
                 "type": "null"
@@ -804,22 +740,7 @@
             "timer": {
               "anyOf": [
                 {
-                  "type": "object",
-                  "required": [
-                    "code",
-                    "location"
-                  ],
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "Timer rule code"
-                    },
-                    "location": {
-                      "type": "string",
-                      "description": "Location of the code file"
-                    }
-                  },
-                  "additionalProperties": false
+                  "$ref": "#/definitions/scriptCode"
                 },
                 {
                   "type": "null"
@@ -898,22 +819,7 @@
             "required": ["timer"],
             "properties": {
               "timer": {
-                "type": "object",
-                "required": [
-                  "code",
-                  "location"
-                ],
-                "properties": {
-                  "code": {
-                    "type": "string",
-                    "description": "Timer rule code"
-                  },
-                  "location": {
-                    "type": "string",
-                    "description": "Location of the code file"
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/definitions/scriptCode"
               },
               "rule": {
                 "type": "null"


### PR DESCRIPTION
Standardizes mapping code definitions across core, extension, function, and workflow schemas. Adds 'type' (Global/Local) and 'encoding' (B64/NAT) properties, and refactors workflow timer rules to use the shared scriptCode definition for consistency.

## Summary by Sourcery

Standardize mapping code schema fields across core, extension, function, and workflow JSON schemas to ensure consistent script code representation.

New Features:
- Introduce shared mapping script code properties, including type and encoding, across all relevant schemas.

Enhancements:
- Refactor workflow timer rule definitions to reuse the common script code schema for consistency and reuse.