### PR TITLE
Make 'code' property conditionally required in mapping schemas

### DIFF
--- a/schemas/core-schema.schema.json
+++ b/schemas/core-schema.schema.json
@@ -306,9 +306,6 @@
         },
         "mappingReference": {
             "type": "object",
-            "required": [
-                "code"
-            ],
             "properties": {
                 "type": {
                     "type": "string",
@@ -335,6 +332,19 @@
                     "enum": ["B64", "NAT"],
                     "default": "B64"
                 }
+            },
+            "if": {
+                "properties": {
+                    "type": {
+                        "const": "G"
+                    }
+                }
+            },
+            "then": {
+                "required": []
+            },
+            "else": {
+                "required": ["code"]
             }
         }
     }

--- a/schemas/extension-definition.schema.json
+++ b/schemas/extension-definition.schema.json
@@ -172,9 +172,6 @@
                         "mapping": {
                             "type": "object",
                             "description": "Extension mapping code",
-                            "required": [
-                                "code"
-                            ],
                             "properties": {
                                 "type": {
                                     "type": "string",
@@ -203,7 +200,20 @@
                                     "default": "B64"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": false,
+                            "if": {
+                                "properties": {
+                                    "type": {
+                                        "const": "G"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": []
+                            },
+                            "else": {
+                                "required": ["code"]
+                            }
                         }
                     },
                     "additionalProperties": false

--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -149,9 +149,6 @@
                         "mapping": {
                             "type": "object",
                             "description": "Function mapping code",
-                            "required": [
-                                "code"
-                            ],
                             "properties": {
                                 "type": {
                                     "type": "string",
@@ -180,7 +177,20 @@
                                     "default": "B64"
                                 }
                             },
-                            "additionalProperties": false
+                            "additionalProperties": false,
+                            "if": {
+                                "properties": {
+                                    "type": {
+                                        "const": "G"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "required": []
+                            },
+                            "else": {
+                                "required": ["code"]
+                            }
                         }
                     },
                     "additionalProperties": false

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -390,10 +390,20 @@
           "default": "B64"
         }
       },
-      "required": [
-        "code"
-      ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "type": {
+            "const": "G"
+          }
+        }
+      },
+      "then": {
+        "required": []
+      },
+      "else": {
+        "required": ["code"]
+      }
     },
     "subFlow": {
       "anyOf": [


### PR DESCRIPTION
Updated mapping-related schema definitions to require the 'code' property only when the 'type' is not 'G'. This change improves schema flexibility and allows for mappings of type 'G' without a mandatory 'code' property.

## Summary by Sourcery

Enhancements:
- Update core, extension, function, and workflow mapping-related JSON Schemas to require `code` only when `type` is not `G`, allowing `G`-type mappings without a `code` value.