### PR TITLE
feat(schemas): Authorization mechanism #382 - roles and queryRoles

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -219,10 +219,35 @@
                             }
                         }
                     }
+                },
+                "roles": {
+                    "type": "array",
+                    "description": "Function roles for authorization. Domain-qualified roles. DENY overrides ALLOW.",
+                    "items": {
+                        "$ref": "#/definitions/roleGrant"
+                    }
                 }
             },
             "additionalProperties": false
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "definitions": {
+        "roleGrant": {
+            "type": "object",
+            "required": ["role", "grant"],
+            "properties": {
+                "role": {
+                    "type": "string",
+                    "description": "Role name (current: Amorphie roles; future: domain.rolename)"
+                },
+                "grant": {
+                    "type": "string",
+                    "enum": ["allow", "deny"],
+                    "description": "DENY always overrides ALLOW"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
 }

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -223,11 +223,34 @@
               "$ref": "#/definitions/reference"
             }
           }
+        },
+        "queryRoles": {
+          "type": "array",
+          "description": "Root-level query roles for instance access. Used when state has no queryRoles. DENY overrides ALLOW.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
         }
       }
     }
   },
   "definitions": {
+    "roleGrant": {
+      "type": "object",
+      "required": ["role", "grant"],
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Role name (current: Amorphie roles; future: domain.rolename)"
+        },
+        "grant": {
+          "type": "string",
+          "enum": ["allow", "deny"],
+          "description": "DENY always overrides ALLOW"
+        }
+      },
+      "additionalProperties": false
+    },
     "viewDefinition": {
       "anyOf": [
         {
@@ -658,6 +681,13 @@
                 }
               ],
               "description": "Input mapping for the transition"
+            },
+            "roles": {
+              "type": "array",
+              "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+              "items": {
+                "$ref": "#/definitions/roleGrant"
+              }
             }
           }
         },
@@ -863,6 +893,13 @@
               "description": "States where this shared transition is available",
               "items": {
                 "type": "string"
+              }
+            },
+            "roles": {
+              "type": "array",
+              "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+              "items": {
+                "$ref": "#/definitions/roleGrant"
               }
             },
             "schema": {
@@ -1149,6 +1186,13 @@
           ],
           "description": "Input mapping for the transition"
         },
+        "roles": {
+          "type": "array",
+          "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
+        },
         "schema": {
           "anyOf": [
             {
@@ -1244,6 +1288,13 @@
             }
           ],
           "description": "Optional mapping definition for cancel transition input data transformation"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
         }
       },
       "additionalProperties": false
@@ -1330,6 +1381,13 @@
             }
           ],
           "description": "Optional mapping definition for exit transition input data transformation"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
         }
       },
       "additionalProperties": false
@@ -1416,6 +1474,13 @@
             }
           ],
           "description": "Optional mapping definition for update data transition input data transformation"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
         }
       },
       "additionalProperties": false
@@ -1514,6 +1579,13 @@
             }
           ],
           "description": "State-level error boundary. Applied when no task-level boundary handles the error."
+        },
+        "queryRoles": {
+          "type": "array",
+          "description": "State-level query roles for instance access. Overrides root queryRoles when present. DENY overrides ALLOW.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
Adds schema support for [Authorization Mechanism #382](https://github.com/burgan-tech/vnext/issues/382).

## Changes

### workflow-definition.schema.json
- **roleGrant** definition: `{ role, grant: allow|deny }`
- **Transition roles** (optional): `roles` on transition, sharedTransition, startTransition, cancelTransition, exitTransition, updateDataTransition
- **queryRoles** (optional): root `attributes.queryRoles` and per-state `state.queryRoles`

### function-definition.schema.json
- **roleGrant** definition (same shape)
- **attributes.roles** (optional) for function-level authorization

All new fields are optional; backward compatible.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add optional authorization schema support for roles and queryRoles in workflow and function definitions.

New Features:
- Define roleGrant objects for specifying allow or deny role-based access in workflow and function schemas.
- Add optional roles attributes to workflow transitions and function definitions for authorization control.
- Introduce optional queryRoles attributes at workflow root and state levels for query-specific authorization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based authorization for functions and workflows, enabling specification of access roles at function level and for individual transitions.
  * Implemented allow/deny authorization semantics where DENY always overrides ALLOW, providing fine-grained access control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->