### PR TITLE
Resolve schema $id via unpkg and add version injection at publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "index.d.ts",
   "files": [
     "schemas/",
+    "vocabularies/",
     "index.js",
     "index.d.ts",
     "README.md"
@@ -15,7 +16,10 @@
     "test:coverage": "nyc npm test",
     "lint": "eslint . --fix",
     "validate": "npm run test",
-    "prepublishOnly": "npm run validate && npm run lint"
+    "inject-schema-version": "node scripts/inject-schema-version.js --inject",
+    "restore-schema-version": "node scripts/inject-schema-version.js --restore",
+    "prepublishOnly": "npm run inject-schema-version && npm run validate && npm run lint",
+    "postpublish": "npm run restore-schema-version"
   },
   "keywords": [
     "vnext",

--- a/schemas/core-header.schema.json
+++ b/schemas/core-header.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://vnext.com/schemas/core-header.schema.json",
+  "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/core-header.schema.json",
   "title": "HTTP Headers",
   "description": "Schema for vNext Header Component Definition JSON files (sys-schemas flow)",
   "type": "object",

--- a/schemas/core-schema.schema.json
+++ b/schemas/core-schema.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/core-schema.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/core-schema.schema.json",
     "title": "vNext Core Schema Definition",
     "description": "Schema for vNext Core Schema Definition JSON files",
     "type": "object",

--- a/schemas/extension-definition.schema.json
+++ b/schemas/extension-definition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/extension-definition.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/extension-definition.schema.json",
     "title": "vNext Extension Definition",
     "description": "Schema for vNext Extension Component Definition JSON files (sys-extensions flow)",
     "type": "object",

--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/function-definition.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/function-definition.schema.json",
     "title": "vNext Function Definition",
     "description": "Schema for vNext Function Component Definition JSON files (sys-functions flow)",
     "type": "object",

--- a/schemas/schema-definition.schema.json
+++ b/schemas/schema-definition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/schema-definition.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/schema-definition.schema.json",
     "title": "vNext Schema Definition",
     "description": "Schema for vNext Schema Component Definition JSON files (sys-schemas flow)",
     "type": "object",

--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/task-definition.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/task-definition.schema.json",
     "title": "vNext Task Definition",
     "description": "Schema for vNext Task Component Definition JSON files (sys-tasks flow)",
     "type": "object",

--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://vnext.io/schemas/view-definition.schema.json",
+    "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/view-definition.schema.json",
     "title": "vNext View Definition",
     "description": "Schema for vNext View Component Definition JSON files (sys-views flow)",
     "type": "object",

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://vnext.io/schemas/workflow-definition.schema.json",
+  "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/schemas/workflow-definition.schema.json",
   "title": "vNext Workflow Definition",
   "description": "Schema for vNext Workflow Component Definition JSON files (sys-flows flow)",
   "type": "object",

--- a/scripts/inject-schema-version.js
+++ b/scripts/inject-schema-version.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PLACEHOLDER = '__SCHEMA_VERSION__';
+const ROOT = path.resolve(__dirname, '..');
+const PACKAGE_JSON = path.join(ROOT, 'package.json');
+
+function getJsonFiles() {
+  const dirs = ['schemas', 'vocabularies'];
+  const files = [];
+  for (const dir of dirs) {
+    const fullPath = path.join(ROOT, dir);
+    if (!fs.existsSync(fullPath)) continue;
+    for (const name of fs.readdirSync(fullPath)) {
+      if (name.endsWith('.json')) files.push(path.join(fullPath, name));
+    }
+  }
+  const workflowPath = path.join(ROOT, 'workflow.json');
+  if (fs.existsSync(workflowPath)) files.push(workflowPath);
+  return files;
+}
+
+function inject() {
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+  const version = pkg.version;
+  if (!version) throw new Error('package.json has no version');
+  const files = getJsonFiles();
+  let replaced = 0;
+  for (const file of files) {
+    let content = fs.readFileSync(file, 'utf8');
+    if (content.includes(PLACEHOLDER)) {
+      content = content.split(PLACEHOLDER).join(version);
+      fs.writeFileSync(file, content, 'utf8');
+      replaced++;
+    }
+  }
+  console.log(`inject-schema-version: replaced ${PLACEHOLDER} with ${version} in ${replaced} file(s)`);
+}
+
+function restore() {
+  const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, 'utf8'));
+  const version = pkg.version;
+  if (!version) throw new Error('package.json has no version');
+  const files = getJsonFiles();
+  const pattern = new RegExp('@' + escapeRegExp(version) + '/', 'g');
+  let restored = 0;
+  for (const file of files) {
+    let content = fs.readFileSync(file, 'utf8');
+    const newContent = content.replace(pattern, '@' + PLACEHOLDER + '/');
+    if (newContent !== content) {
+      fs.writeFileSync(file, newContent, 'utf8');
+      restored++;
+    }
+  }
+  console.log(`inject-schema-version: restored ${PLACEHOLDER} in ${restored} file(s)`);
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const mode = process.argv[2];
+if (mode === '--restore') restore();
+else if (mode === '--inject' || !mode) inject();
+else {
+  console.error('Usage: node inject-schema-version.js [--inject|--restore]');
+  process.exit(1);
+}

--- a/vocabularies/roles-vocab.json
+++ b/vocabularies/roles-vocab.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/vocabularies/roles-vocab.json",
+  "title": "vNext Roles Vocabulary",
+  "description": "Vocabulary for role grant. Reusable in queryRoles, roles arrays, and field-level visibility (e.g. master schema). DENY overrides ALLOW.",
+  "definitions": {
+    "roleGrant": {
+      "type": "object",
+      "required": ["role", "grant"],
+      "description": "Single role grant. Used in roles/queryRoles arrays for allow/deny. DENY always overrides ALLOW.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Role name (e.g. domain.rolename such as morph-idm.maker, morph-idm.approver)"
+        },
+        "grant": {
+          "type": "string",
+          "enum": ["allow", "deny"],
+          "description": "DENY always overrides ALLOW"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **Roles vocabulary**: Added `vocabularies/roles-vocab.json` with `roleGrant` definition for reuse in queryRoles and field-level visibility (related to #402).
- **Schema $id resolution**: Replaced all schema/vocabulary `$id` values with unpkg URLs using placeholder `__SCHEMA_VERSION__` so the published package resolves from npm CDN.
- **Version injection**: Added `scripts/inject-schema-version.js`:
  - `--inject`: replaces `__SCHEMA_VERSION__` with `package.json` version (run in `prepublishOnly`).
  - `--restore`: reverts version back to placeholder after publish (run in `postpublish`).
- **npm lifecycle**: `prepublishOnly` runs inject → validate → lint; `postpublish` runs restore so the repo keeps the placeholder in source.

No manual version bumps in schema files when releasing new package versions.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce versioned JSON schema and vocabulary publishing via unpkg-compatible $id values with automatic version injection during npm publish.

New Features:
- Add a reusable roles vocabulary JSON file for role-related definitions.

Enhancements:
- Update schema and vocabulary $id values to resolve via unpkg URLs parameterized by a schema version placeholder.

Build:
- Include the vocabularies directory in the published package files.
- Add inject/restore schema version scripts and wire them into prepublishOnly and postpublish npm lifecycle hooks to manage version placeholders automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role grant vocabulary for managing role-based permissions.

* **Chores**
  * Updated schema identifiers to resolve from CDN with automatic versioning support.
  * Expanded published package contents to include vocabularies directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->