### PR TITLE
View definition: type-dependent content (string | JSON) and remove platformOverrides

### DIFF
--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -95,9 +95,7 @@
                     ]
                 },
                 "content": {
-                    "type": "string",
-                    "description": "View content. Can be in JSON, HTML or Markdown format.",
-                    "minLength": 1
+                    "description": "View content. Type-dependent: string for all types (backward compatible); for type 1 (JSON), 4 (DEEPLINK), 5 (HTTP), 6 (URN) also accepts JSON object or array."
                 },
                 "labels": {
                     "type": "array",
@@ -155,275 +153,44 @@
                         }
                     ]
                 },
-                "platformOverrides": {
-                    "anyOf": [
-                        {
-                            "type": "object",
-                            "properties": {
-                                "android": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "integer",
-                                                    "description": "Content type of the View to be overridden in Android environment",
-                                                    "oneOf": [
-                                                        {
-                                                            "const": 1,
-                                                            "description": "JSON content type"
-                                                        },
-                                                        {
-                                                            "const": 2,
-                                                            "description": "HTML content type"
-                                                        },
-                                                        {
-                                                            "const": 3,
-                                                            "description": "Markdown content type"
-                                                        },
-                                                        {
-                                                            "const": 4,
-                                                            "description": "Deeplink content type"
-                                                        },
-                                                        {
-                                                            "const": 5,
-                                                            "description": "Http content type"
-                                                        },
-                                                        {
-                                                            "const": 6,
-                                                            "description": "URN content type"
-                                                        }
-                                                    ]
-                                                },
-                                                "content": {
-                                                    "type": "string",
-                                                    "description": "Content of the View to be overridden in Android environment.",
-                                                    "examples": [
-                                                        "core",
-                                                        "idm",
-                                                        "banking",
-                                                        "payment"
-                                                    ]
-                                                },
-                                                "display": {
-                                                    "type": "string",
-                                                    "description": "Display type of the View.",
-                                                    "pattern": "^[a-z\\-]+$",
-                                                    "maxLength": 100,
-                                                    "examples": [
-                                                        "full-page",
-                                                        "popup",
-                                                        "bottom-sheet",
-                                                        "inline"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "content",
-                                                "display"
-                                            ],
-                                            "additionalProperties": false,
-                                            "examples": [
-                                                {
-                                                    "type": 1,
-                                                    "content": "{ \"widget\": \"MaterialCard\", \"title\": \"Android Profile\" }",
-                                                    "display": "full-page"
-                                                },
-                                                {
-                                                    "type": 2,
-                                                    "content": "<div class=\"profile\">Android Profile</div>",
-                                                    "display": "inline"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "null"
-                                        }
-                                    ],
-                                    "description": "View to be overridden in Android environment"
-                                },
-                                "ios": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "integer",
-                                                    "description": "Content type of the View to be overridden in iOS environment",
-                                                    "oneOf": [
-                                                        {
-                                                            "const": 1,
-                                                            "description": "JSON content type"
-                                                        },
-                                                        {
-                                                            "const": 2,
-                                                            "description": "HTML content type"
-                                                        },
-                                                        {
-                                                            "const": 3,
-                                                            "description": "Markdown content type"
-                                                        },
-                                                        {
-                                                            "const": 4,
-                                                            "description": "Deeplink content type"
-                                                        },
-                                                        {
-                                                            "const": 5,
-                                                            "description": "Http content type"
-                                                        },
-                                                        {
-                                                            "const": 6,
-                                                            "description": "URN content type"
-                                                        }
-                                                    ]
-                                                },
-                                                "content": {
-                                                    "type": "string",
-                                                    "description": "Content of the View to be overridden in iOS environment.",
-                                                    "pattern": "^[a-zA-Z\\-]+$",
-                                                    "maxLength": 100,
-                                                    "examples": [
-                                                        "core",
-                                                        "idm",
-                                                        "banking",
-                                                        "payment"
-                                                    ]
-                                                },
-                                                "display": {
-                                                    "type": "string",
-                                                    "description": "Display type of the View.",
-                                                    "pattern": "^[a-z\\-]+$",
-                                                    "maxLength": 100,
-                                                    "examples": [
-                                                        "full-page",
-                                                        "popup",
-                                                        "bottom-sheet",
-                                                        "inline"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "content",
-                                                "display"
-                                            ],
-                                            "additionalProperties": false,
-                                            "examples": [
-                                                {
-                                                    "type": 1,
-                                                    "content": "{ \"widget\": \"MaterialCard\", \"title\": \"iOS Profile\" }",
-                                                    "display": "full-page"
-                                                },
-                                                {
-                                                    "type": 2,
-                                                    "content": "<div class=\"profile\">iOS Profile</div>",
-                                                    "display": "inline"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "null"
-                                        }
-                                    ],
-                                    "description": "View to be overridden in iOS environment"
-                                },
-                                "web": {
-                                    "anyOf": [
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "type": {
-                                                    "type": "integer",
-                                                    "description": "Content type of the View to be overridden in Web environment",
-                                                    "oneOf": [
-                                                        {
-                                                            "const": 1,
-                                                            "description": "JSON content type"
-                                                        },
-                                                        {
-                                                            "const": 2,
-                                                            "description": "HTML content type"
-                                                        },
-                                                        {
-                                                            "const": 3,
-                                                            "description": "Markdown content type"
-                                                        },
-                                                        {
-                                                            "const": 4,
-                                                            "description": "Deeplink content type"
-                                                        },
-                                                        {
-                                                            "const": 5,
-                                                            "description": "Http content type"
-                                                        },
-                                                        {
-                                                            "const": 6,
-                                                            "description": "URN content type"
-                                                        }
-                                                    ]
-                                                },
-                                                "content": {
-                                                    "type": "string",
-                                                    "description": "Content of the View to be overridden in Web environment.",
-                                                    "pattern": "^[a-zA-Z\\-]+$",
-                                                    "maxLength": 100,
-                                                    "examples": [
-                                                        "core",
-                                                        "idm",
-                                                        "banking",
-                                                        "payment"
-                                                    ]
-                                                },
-                                                "display": {
-                                                    "type": "string",
-                                                    "description": "Display type of the View.",
-                                                    "pattern": "^[a-z\\-]+$",
-                                                    "maxLength": 100,
-                                                    "examples": [
-                                                        "full-page",
-                                                        "popup",
-                                                        "bottom-sheet",
-                                                        "inline"
-                                                    ]
-                                                }
-                                            },
-                                            "required": [
-                                                "content",
-                                                "display"
-                                            ],
-                                            "additionalProperties": false,
-                                            "examples": [
-                                                {
-                                                    "type": 1,
-                                                    "content": "{ \"widget\": \"MaterialCard\", \"title\": \"Web Profile\" }",
-                                                    "display": "full-page"
-                                                },
-                                                {
-                                                    "type": 2,
-                                                    "content": "<div class=\"profile\">Web Profile</div>",
-                                                    "display": "inline"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "type": "null"
-                                        }
-                                    ],
-                                    "description": "View to be overridden in Web environment"
-                                }
-                            },
-                            "additionalProperties": false
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "description": "Views to be overridden on a platform basis"
-                },
                 "_comment": {
                     "type": "string",
                     "description": "Comment about the view"
                 }
             },
+            "allOf": [
+                {
+                    "if": {
+                        "properties": { "type": { "enum": [1, 4, 5, 6] } },
+                        "required": ["type"]
+                    },
+                    "then": {
+                        "properties": {
+                            "content": {
+                                "oneOf": [
+                                    { "type": "string", "minLength": 1 },
+                                    { "type": "object" },
+                                    { "type": "array" }
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "type": { "enum": [2, 3] } },
+                        "required": ["type"]
+                    },
+                    "then": {
+                        "properties": {
+                            "content": {
+                                "type": "string",
+                                "minLength": 1
+                            }
+                        }
+                    }
+                }
+            ],
             "additionalProperties": false
         }
     },


### PR DESCRIPTION
## Summary

Implements [issue #85](https://github.com/burgan-tech/vnext-schema/issues/85): type-dependent `content` field with backward compatibility, and removes `platformOverrides` from the view definition schema.

## Changes

### Content field (issue #85)
- **Backward compatibility:** `content` remains valid as **string** for all view types (1–6). Existing view definitions keep validating.
- **Type-dependent validation:**
  - **Types 1 (JSON), 4 (DEEPLINK), 5 (HTTP), 6 (URN):** `content` accepts **string** or **JSON** (object/array) via conditional `if/then` in the schema.
  - **Types 2 (HTML), 3 (Markdown):** `content` stays **string** only (`minLength: 1`).

### platformOverrides removed
- `attributes.platformOverrides` (android, ios, web) has been removed from the schema.

## Acceptance criteria (from #85)
- [x] String `content` is valid for every `attributes.type` (1–6).
- [x] For `type` in { 1, 4, 5, 6 }, `content` also validates when it is a JSON object/array.
- [x] For `type` in { 2, 3 }, `content` is string only.
- [x] Existing view definitions using string `content` continue to validate.
- [x] Schema updated (platformOverrides scope removed per product decision).

Closes #85

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update the view definition schema to support type-dependent content validation while cleaning up deprecated platform-specific attributes.

New Features:
- Allow the view definition content field to accept either string or JSON for selected view types based on the type value.

Enhancements:
- Tighten content field validation so HTML and Markdown view types continue to require non-empty string content.

Chores:
- Remove the attributes.platformOverrides structure from the view definition schema in line with current product decisions.