### PR TITLE
Make flowVersion required in workflow-definition schema

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "key",
     "flow",
+    "flowVersion",
     "domain",
     "version",
     "tags",


### PR DESCRIPTION
## Summary
Adds `flowVersion` to the top-level `required` array in `workflow-definition.schema.json` so that workflow component definitions must include a flow version.

## Changes
- **schemas/workflow-definition.schema.json**: `flowVersion` added to `required` (after `flow`, before `domain`).

## Related
Closes #88

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Enhancements:
- Tighten the workflow-definition JSON schema so that flowVersion is now a mandatory top-level property for workflow definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Workflow definitions now require specifying a flow version. This field was previously optional but is now mandatory when creating or updating workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->