### PR TITLE
Make config required in task-definition schema

### DIFF
--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -59,7 +59,8 @@
             "type": "object",
             "description": "Task definition attributes",
             "required": [
-                "type"
+                "type",
+                "config"
             ],
             "properties": {
                 "type": {


### PR DESCRIPTION
## Summary
Adds `config` to the `required` array in `task-definition.schema.json` `attributes` so that every task definition must include a config object.

## Changes
- **schemas/task-definition.schema.json**: `config` added to `attributes.required` (alongside `type`).

## Related
Closes #89

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Prevent invalid task definitions without a config object by enforcing config as a required schema attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Task definitions now require a `config` field in addition to the existing `type` field. Existing task definitions without a `config` field will need to be updated to comply with the new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->