### PR TITLE
build updated

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -51,8 +51,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
+        always-auth: false
         cache: 'npm'
     
     - name: Calculate version
@@ -282,10 +283,7 @@ jobs:
       if: ${{ github.event.inputs.registry_target != 'github' }}
       uses: JS-DevTools/npm-publish@v4
       with:
-        token: ${{ secrets.NPM_TOKEN }}
-        registry: https://registry.npmjs.org
         access: public
-        provenance: true
 
     - name: Publish to GitHub Packages
       id: publish-github


### PR DESCRIPTION
## Summary by Sourcery

Update the build and publish workflow to use a newer Node.js version and simplify npm publish configuration for the public registry.

Build:
- Bump Node.js in the GitHub Actions build-and-publish workflow from 20.x to 24 and disable always-auth for npm registry access.
- Simplify npm publish configuration by relying on default npmjs.org settings instead of explicitly passing token, registry, and provenance options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to use Node.js 24 and optimized NPM publishing configuration for improved stability and build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->