### PR TITLE
v0.0.39

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -51,8 +51,9 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '20.x'
+        node-version: '24'
         registry-url: 'https://registry.npmjs.org'
+        always-auth: false
         cache: 'npm'
     
     - name: Calculate version
@@ -282,10 +283,7 @@ jobs:
       if: ${{ github.event.inputs.registry_target != 'github' }}
       uses: JS-DevTools/npm-publish@v4
       with:
-        token: ${{ secrets.NPM_TOKEN }}
-        registry: https://registry.npmjs.org
         access: public
-        provenance: true
 
     - name: Publish to GitHub Packages
       id: publish-github


### PR DESCRIPTION
## Summary by Sourcery

Update build and publish workflow configuration for Node.js and npm publishing.

Build:
- Bump GitHub Actions Node.js setup to version 24 and configure npm always-auth to false in the build-and-publish workflow.
- Adjust npm publish step configuration by relying on default authentication and registry settings instead of explicitly passing token, registry, and provenance options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version from 20.x to 24 in the build workflow
  * Modified NPM publishing configuration to disable explicit token and registry inputs and package provenance generation
  * Updated Node.js setup to disable automatic authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->