### PR TITLE
feat(task-definition): add acceptedStatusCodes field to HTTP-invoking task types

### DIFF
--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -262,6 +262,21 @@
                                         "type": "integer",
                                         "minimum": 1,
                                         "description": "Timeout in seconds"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -450,6 +465,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -592,6 +622,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -681,6 +726,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -754,6 +814,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -833,6 +908,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [
@@ -917,6 +1007,21 @@
                                     "validateSsl": {
                                         "type": "boolean",
                                         "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
                                     }
                                 },
                                 "required": [


### PR DESCRIPTION
## Summary
- Add optional `acceptedStatusCodes` field to all task types that perform HTTP invocations
- Allows workflow developers to declare specific HTTP error status codes (or wildcard patterns) that should be treated as successful, bypassing the ErrorBoundary
- Affects 7 task types: DaprServiceTask (3), HttpTask (6), StartTriggerTask (11), DirectTriggerTask (12), GetInstanceDataTask (13), SubProcessTask (14), GetInstancesTask (15)

## Changes
- `schemas/task-definition.schema.json` — `acceptedStatusCodes` array property added to the `config` block of each affected task type

## Test Plan
- [ ] Run `npm test` — all schemas validate successfully
- [ ] Verify `acceptedStatusCodes` accepts exact codes (`"403"`, `"404"`)
- [ ] Verify wildcard patterns (`"4xx"`, `"40x"`, `"5xx"`, `"50x"`) are accepted
- [ ] Verify the field remains optional (no `required` change)

## Notes
Closes #103

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

New Features:
- Introduce an acceptedStatusCodes field on HTTP-based task configurations to declare HTTP status codes or patterns that should be treated as successful responses.