### PR TITLE
feat(workflow): add optional mapping property to workflowTimeout

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1759,6 +1759,17 @@
         },
         "timer": {
           "$ref": "#/definitions/timerConfig"
+        },
+        "mapping": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/scriptCode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional mapping script for dynamic timeout duration calculation. When provided, the script is executed at runtime to determine the timeout schedule. If the mapping fails, the static timer duration is used as fallback."
         }
       }
     },


### PR DESCRIPTION
## Summary
- Add optional `mapping` property to `workflowTimeout` definition for dynamic timeout duration calculation
- When provided, the mapping script is executed at runtime; if it fails, the static `timer.duration` is used as fallback
- Backward compatible — `mapping` is not required, existing workflow definitions remain valid

## Changes
- `schemas/workflow-definition.schema.json` — added `mapping` (anyOf: scriptCode | null) to `definitions.workflowTimeout.properties`

## Test Plan
- [ ] `npm test` passes — all schemas remain valid
- [ ] Existing workflow JSON files without `mapping` continue to validate
- [ ] A workflow JSON with `mapping: { "code": "...", "encoding": "B64" }` in timeout validates
- [ ] A workflow JSON with `mapping: null` in timeout validates

Closes #106

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

New Features:
- Allow workflowTimeout definitions to include an optional mapping field for dynamic timeout duration evaluation.