### PR TITLE
feat(schemas): extend task/view/workflow schemas with notification ch…

### DIFF
--- a/.cursor/rules/schema-development.mdc
+++ b/.cursor/rules/schema-development.mdc
@@ -1,0 +1,66 @@
+---
+description: Schema development consistency rules -- $ref usage, $comment annotations, version tracking, and change summaries
+globs: schemas/**/*.schema.json
+alwaysApply: false
+---
+
+# Schema Development Rules
+
+## $ref First
+
+Reuse definitions via `$ref` instead of duplicating structures. The workflow schema already has deeply nested patterns; every new type that appears in more than one place must be a `#/definitions/` entry.
+
+```json
+// GOOD -- shared definition
+"triggerType": { "$ref": "#/definitions/triggerType" }
+
+// BAD -- inline duplication
+"triggerType": { "type": "integer", "enum": [0, 1, 2, 3], ... }
+```
+
+When the same structure exists across multiple schema files, extract it to `vocabularies/` and reference it with a full `$id` URI.
+
+## $comment Annotation (mandatory)
+
+Every new or modified property MUST have a `$comment` annotation following the DSL:
+
+```
+"$comment": "since:X.X.X"                          -- basic field
+"$comment": "since:X.X.X;experimental"              -- experimental field
+"$comment": "since:X.X.X;values:A=X.X.X,B=Y.Y.Y"  -- enum with per-value versions
+```
+
+Standalone definitions (enum types like `triggerType`, `stateType`) also need `$comment` at the definition root level, not only inside `properties`.
+
+## Version Tracking
+
+Before adding or modifying a field, ASK the user:
+
+> "Which schema version should this field target? (e.g., 0.0.45)"
+
+Use the answer in the `$comment` annotation. Never guess or default to `0.0.1` for new fields.
+
+When adding a new enum value to an existing definition, update only the new value's version in the `values:` DSL -- do not change existing value versions.
+
+## After Every Change
+
+1. Run `npm run generate-features` to regenerate `features.json`
+2. Run `npm test` to validate all schemas and the feature catalog
+3. Provide a short summary to the user covering:
+   - **Changed fields**: list each field with its component, path, and since version
+   - **Feature matrix delta**: a table of added/modified/removed fields (use the feature-catalog-matrix skill format)
+   - **Breaking changes**: explicitly call out any of the following:
+     - Required field removed or made optional
+     - Enum value removed
+     - Type changed (e.g., string -> object)
+     - Pattern or constraint tightened (stricter validation)
+     - `additionalProperties` changed from true/absent to false
+
+## Breaking Change Checklist
+
+When a change is potentially breaking, flag it clearly:
+
+```
+BREAKING: [component].[field] -- [description]
+Example: BREAKING: workflow.triggerType -- removed value 4 (Signal)
+```

--- a/.cursor/skills/component-matrix-docs/SKILL.md
+++ b/.cursor/skills/component-matrix-docs/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: component-matrix-docs
+description: >-
+  Generate a detailed component constraint matrix document from a vNext schema file.
+  Analyzes required/optional/conditional fields, type-based constraints, if/then rules,
+  and enum restrictions. Outputs to docs/components/. Use when the user asks for a
+  component matrix, constraint documentation, field reference, or says a component name
+  like "workflow", "task", "view", "function", "extension", "schema".
+---
+
+# Component Matrix Documentation Generator
+
+Generate a comprehensive constraint matrix for a vNext schema component and write it to `docs/components/<component-name>.md`.
+
+## Input
+
+The user provides a **component name**. Map it to the schema file:
+
+| Input | Schema File |
+|-------|-------------|
+| workflow | `schemas/workflow-definition.schema.json` |
+| task | `schemas/task-definition.schema.json` |
+| view | `schemas/view-definition.schema.json` |
+| function | `schemas/function-definition.schema.json` |
+| extension | `schemas/extension-definition.schema.json` |
+| schema | `schemas/schema-definition.schema.json` |
+| core-header | `schemas/core-header.schema.json` |
+| core-schema | `schemas/core-schema.schema.json` |
+
+## Workflow
+
+1. Read the full schema file
+2. Analyze all structures: top-level properties, `attributes`, nested objects, `definitions`, `if/then/else` conditionals
+3. Generate the matrix document
+4. Write to `docs/components/<component-name>.md`
+
+## Output Format
+
+Use the structure below. Adapt sections based on schema complexity -- simple components may skip the conditional matrix section.
+
+### Document Header
+
+```markdown
+# <Component Title> - Constraint Matrix
+> Source: `schemas/<file>.schema.json`
+> Generated: YYYY-MM-DD
+```
+
+### 1. Envelope (Top-Level Fields)
+
+Every component shares a common envelope. Document it first:
+
+```markdown
+## Envelope
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| key | string | Yes | `^[a-z0-9-]+$` |
+| version | string | Yes | semver pattern |
+| domain | string | Yes | `^[a-z0-9-]+$` |
+| flow | string | Yes | `^[a-z0-9-]+$` |
+| flowVersion | string | Yes | semver pattern |
+| tags | string[] | Yes | - |
+```
+
+### 2. Attributes Overview
+
+List all `attributes` properties with their type, required status, and brief constraint:
+
+```markdown
+## Attributes
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| type | enum | Yes | No | C, F, S, P |
+| states | state[] | Yes | No | Must contain exactly 1 initial state |
+| startTransition | object | Yes | No | triggerType must be 0 |
+| cancel | object | No | Yes | triggerType must be 0 |
+```
+
+### 3. Definitions / Enum Reference
+
+List all `definitions` that are enums or reusable types:
+
+```markdown
+## Definitions Reference
+
+### triggerType
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | Manual | User-triggered |
+| 1 | Automatic | Rule-based auto trigger |
+| 2 | Scheduled | Timer-based trigger |
+| 3 | Event | External event trigger |
+
+### stateType
+| Value | Name |
+|-------|------|
+| 1 | Initial |
+| 2 | Intermediate |
+| ... | ... |
+```
+
+### 4. Sub-Structure Detail Tables
+
+For each complex nested structure (state, transition, etc.), create a dedicated section:
+
+```markdown
+## State
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | kebab-case |
+| stateType | enum | Yes | No | 1-5 |
+| transitions | transition[] | No | No | max 1 if stateType=5 (Wizard) |
+```
+
+### 5. Conditional Constraint Matrix (Key Section)
+
+This is the most important section. For structures that behave differently based on a discriminator field (e.g., `triggerType`, `type`, `stateType`), produce a **cross-reference matrix**.
+
+#### Rules for Building the Matrix
+
+1. **Identify the discriminator**: the field whose value activates `if/then` blocks
+2. **List all discriminator values** as column headers
+3. **List all conditional fields** as rows
+4. **Cell values**:
+   - **Required** = field is mandatory for this discriminator value
+   - **Optional** = field is allowed but not required
+   - **Nullable** = field can be explicitly null
+   - **null** = field must be null or absent (forbidden)
+   - **Optional/null** = field is allowed, can be null
+   - **"value"** = field has a fixed `const` value
+
+Example for state transitions:
+
+```markdown
+## State Transition - triggerType Constraint Matrix
+
+| Field | Manual (0) | Auto (1) | Auto Default (1+kind:10) | Scheduled (2) | Event (3) |
+|-------|:----------:|:--------:|:------------------------:|:--------------:|:---------:|
+| key | **Required** | **Required** | **Required** | **Required** | **Required** |
+| target | **Required** | **Required** | **Required** | **Required** | **Required** |
+| triggerType | **Required** | **Required** | **Required** | **Required** | **Required** |
+| triggerKind | Optional | Optional | **Required** (=10) | Optional | Optional |
+| rule | null | **Required** | Optional/null | null | null |
+| timer | null | null | null | **Required** | null |
+| view | Optional/null | null | null | null | null |
+| schema | Optional/null | null | null | null | Optional/null |
+| mapping | Optional/null | null | null | null | Optional/null |
+```
+
+#### Multiple Matrices per Component
+
+A single component may need multiple matrices. For workflow, produce separate matrices for:
+- State transition by triggerType
+- Shared transition by triggerType
+- startTransition (single-column, manual only)
+- cancelTransition (single-column, manual only)
+- exitTransition (single-column, manual only)
+- updateDataTransition (single-column, manual only)
+- state by stateType (if constraints differ)
+
+For task, produce matrices by task `type` (HTTP, gRPC, AMQP, etc.).
+
+### 6. View Definition Variants
+
+When `viewDefinition` is referenced, document both supported formats:
+
+```markdown
+## viewDefinition
+
+Supports two formats:
+
+### Single View
+| Field | Type | Required |
+|-------|------|----------|
+| view | reference | Yes |
+| extensions | string[] | No |
+| loadData | boolean | No |
+
+### Rule-Based View
+| Field | Type | Required |
+|-------|------|----------|
+| rules | viewRule[] | Yes (min 1) |
+| default | object | No |
+| default.view | reference | Yes (if default) |
+| default.extensions | string[] | No |
+| default.loadData | boolean | No |
+```
+
+### 7. Cross-References
+
+At the end, list which other components this schema references and where:
+
+```markdown
+## Cross-References
+
+| Referenced Component | Used In |
+|---------------------|---------|
+| view-definition | state.view, transition.view, cancel.view |
+| task-definition | onExecutionTasks[].task |
+| schema-definition | transition.schema, startTransition.schema |
+```
+
+## Quality Checks
+
+Before writing the file:
+- Every `required` array in the schema must be reflected as "Required" in the matrix
+- Every `if/then` conditional must produce matrix columns or notes
+- Every `const` constraint must show the fixed value
+- Every `anyOf: [type, null]` must show as "Nullable"
+- Every `additionalProperties: false` must be noted
+- Nested structures must have their own section (don't inline deeply)
+
+## Notes
+
+- The output path is always `docs/components/<component-name>.md`
+- One document per component, regenerate fully on each run
+- Use Turkish for descriptions only if the user writes in Turkish; otherwise default to English
+- For detailed viewRule and scriptCode structures, see `workflow-definition.schema.json` definitions

--- a/.cursor/skills/feature-catalog-matrix/SKILL.md
+++ b/.cursor/skills/feature-catalog-matrix/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: feature-catalog-matrix
+description: >-
+  Generate a component-based feature matrix from features.json after schema changes.
+  Use after modifying schema files, running generate-features, or when the user asks
+  for a feature catalog summary, matrix, or support table.
+---
+
+# Feature Catalog Matrix
+
+After any schema development work, generate a human-readable feature matrix document under `docs/feature-catalogs/`.
+
+## When to Run
+
+- After adding, modifying, or removing fields in any `schemas/*.schema.json`
+- After running `npm run generate-features`
+- When the user explicitly asks for a feature matrix or catalog summary
+
+## Workflow
+
+1. Ensure `features.json` is up to date: `npm run generate-features`
+2. Read `features.json` from the project root
+3. Generate the matrix document at `docs/feature-catalogs/feature-matrix.md`
+4. If the change is scoped (only specific components changed), also produce a **delta summary** showing only the affected fields
+
+## Output Format
+
+The generated markdown must follow this structure:
+
+### Header
+
+```markdown
+# vNext Feature Catalog Matrix
+> Generated from `features.json` (schema version X.X.X)
+> Date: YYYY-MM-DD
+```
+
+### Component Overview Table
+
+One row per component with field counts and version range.
+
+```markdown
+## Component Overview
+
+| Component | Fields | Earliest Since | Latest Since |
+|-----------|--------|----------------|--------------|
+| workflow  | 12     | 0.0.1          | 0.0.44       |
+| task      | 8      | 0.0.1          | 0.0.1        |
+| ...       |        |                |              |
+```
+
+### Per-Component Field Matrix
+
+For each component, a detailed table covering every field:
+
+```markdown
+## workflow
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| type | enum | 0.0.1 | Yes | - | C (0.0.1), F (0.0.1), S (0.0.1), P (0.0.1) |
+| cancel | object | 0.0.44 | Yes | - | - |
+| cancel.key | string | 0.0.44 | Yes | - | - |
+| errorBoundary | object | 0.0.39 | Yes | - | - |
+```
+
+Rules for the field matrix:
+- Flatten nested fields with dot notation: `cancel.key`, `cancel.target`
+- For array items, use bracket notation: `transitions[].key`
+- Show enum values inline as `Value (since)` -- truncate if more than 5 values and note "(+N more)"
+- Mark experimental fields with "Yes" in the Experimental column
+- Sort fields alphabetically within each component
+
+### Definitions Matrix
+
+If the component has `definitions` with enum types or constraints, list them separately:
+
+```markdown
+### Definitions
+
+| Definition | Type | Since | Values |
+|------------|------|-------|--------|
+| triggerType | enum | 0.0.1 | 0:Manual (0.0.1), 1:Automatic (0.0.1), 2:Scheduled (0.0.40), 3:Event (0.0.42) |
+| errorAction | enum | 0.0.39 | 0:Abort (0.0.39), 1:Retry (0.0.39), ... (+2 more) |
+```
+
+## Delta Summary (for scoped changes)
+
+When only specific components changed, produce a short delta block at the top of the document:
+
+```markdown
+## Changes in This Version
+
+### Added
+| Component | Field | Since | Type |
+|-----------|-------|-------|------|
+| workflow | updateData | 0.0.44 | object |
+
+### Modified
+| Component | Field | Change |
+|-----------|-------|--------|
+| workflow | triggerType | Added value 3 (Event) since 0.0.42 |
+
+### Breaking Changes
+| Component | Field | Description |
+|-----------|-------|-------------|
+| (none) | | |
+```
+
+## Implementation Notes
+
+- Read `features.json` using the Read tool, then write the matrix using the Write tool
+- The matrix document is purely derived -- never hand-edit it
+- Use `ctx_execute` or direct JS to compute counts and flatten nested fields if the catalog is large
+- Keep the file at `docs/feature-catalogs/feature-matrix.md`

--- a/docs/components/workflow-definition.md
+++ b/docs/components/workflow-definition.md
@@ -1,0 +1,545 @@
+# Workflow Definition - Constraint Matrix
+> Source: `schemas/workflow-definition.schema.json`
+> Generated: 2026-05-14
+
+---
+
+## Envelope
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| key | string | Yes | `^[a-z0-9-]+$` |
+| flow | string | Yes | `^[a-z0-9-]+$` |
+| flowVersion | string | Yes | `^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?$` |
+| domain | string | Yes | `^[a-z0-9-]+$` |
+| version | string | Yes | `^\d+\.\d+\.\d+(-[a-zA-Z]+\.\d+)?$` |
+| tags | string[] | Yes | - |
+| _comment | string | No | - |
+| $schema | string | No | JSON Schema reference |
+
+---
+
+## Attributes
+
+| Field | Type | Required | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| type | enum | Yes | No | `C` (Core), `F` (Flow), `S` (SubFlow), `P` (Sub Process) |
+| labels | languageLabel[] | Yes | No | minItems: 1 |
+| states | state[] | Yes | No | Must contain exactly 1 initial state (stateType: 1) |
+| startTransition | startTransition | Yes | No | triggerType must be 0 (Manual) |
+| timeout | workflowTimeout | No | Yes | Workflow-level timeout configuration |
+| functions | reference[] | No | No | Functions used in the workflow |
+| features | reference[] | No | No | Features (extensions) used in the workflow |
+| sharedTransitions | sharedTransition[] | No | No | Shared transitions across multiple states |
+| extensions | reference[] | No | No | Extensions used in the workflow |
+| errorBoundary | errorBoundary | No | Yes | Global error boundary (since 0.0.39) |
+| cancel | cancelTransition | No | Yes | Cancel transition, manual only (since 0.0.44) |
+| exit | exitTransition | No | Yes | Exit transition, manual only (since 0.0.44) |
+| updateData | updateDataTransition | No | Yes | Update data transition, manual only (since 0.0.44) |
+| schema | object | No | No | Master schema definition (`schema.schema`: reference) |
+| queryRoles | roleGrant[] | No | No | Root-level query roles. Used when state has no queryRoles. DENY overrides ALLOW |
+
+---
+
+## Definitions Reference
+
+### triggerType (State Transition)
+| Value | Name | Since |
+|-------|------|-------|
+| 0 | Manual | 0.0.1 |
+| 1 | Automatic | 0.0.1 |
+| 2 | Scheduled | 0.0.40 |
+| 3 | Event | 0.0.42 |
+
+### triggerType (Shared Transition)
+| Value | Name | Since |
+|-------|------|-------|
+| 0 | Manual | 0.0.1 |
+| 2 | Scheduled | 0.0.1 |
+| 3 | Event | 0.0.1 |
+
+> Auto (1) is **not supported** in shared transitions.
+
+### triggerKind
+| Value | Name | Since |
+|-------|------|-------|
+| 0 | Not applicable | 0.0.1 |
+| 10 | Default auto transition | 0.0.1 |
+
+### versionStrategy
+| Value | Description | Since |
+|-------|-------------|-------|
+| None | No version update | 0.0.1 |
+| Patch | Patch version update | 0.0.1 |
+| Minor | Minor version update | 0.0.1 |
+| Major | Major version update | 0.0.1 |
+
+### stateType
+| Value | Name | Since |
+|-------|------|-------|
+| 1 | Initial | 0.0.1 |
+| 2 | Intermediate | 0.0.1 |
+| 3 | Final | 0.0.1 |
+| 4 | SubFlow | 0.0.1 |
+| 5 | Wizard | 0.0.40 |
+
+### stateSubType
+| Value | Name | Since |
+|-------|------|-------|
+| 0 | No specific subtype (default) | 0.0.1 |
+| 1 | Successful completion | 0.0.1 |
+| 2 | Error condition | 0.0.1 |
+| 3 | Manually terminated | 0.0.1 |
+| 4 | Temporarily suspended | 0.0.1 |
+| 5 | Busy | 0.0.1 |
+| 6 | Human | 0.0.40 |
+
+### errorAction
+| Value | Name | Constraint | Since |
+|-------|------|------------|-------|
+| 0 | Abort | transition must NOT be set | 0.0.39 |
+| 1 | Retry | retryPolicy required | 0.0.39 |
+| 2 | Rollback | transition required | 0.0.39 |
+| 3 | Ignore | - | 0.0.39 |
+| 4 | Notify | transition required | 0.0.42 |
+| 5 | Log | does not affect flow | 0.0.42 |
+
+### backoffType
+| Value | Name | Since |
+|-------|------|-------|
+| 0 | Fixed | 0.0.39 |
+| 1 | Exponential (default) | 0.0.39 |
+
+---
+
+## State
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | `^[a-z0-9-]+$` |
+| stateType | stateType | Yes | No | enum: 1-5 |
+| versionStrategy | versionStrategy | Yes | No | enum |
+| labels | languageLabel[] | Yes | No | minItems: 1 |
+| subType | stateSubType | No | No | enum: 0-6, default: 0 |
+| view | viewDefinition | No | Yes | Single or rule-based |
+| subFlow | subFlow | No | Yes | SubFlow/SubProcess config |
+| transitions | transition[] | No | No | max 1 if stateType=5 (Wizard) |
+| onEntries | onExecuteTask[] | No | No | Tasks on state entry |
+| onExits | onExecuteTask[] | No | No | Tasks on state exit |
+| errorBoundary | errorBoundary | No | Yes | State-level error handling (since 0.0.39) |
+| queryRoles | roleGrant[] | No | No | Overrides root queryRoles. DENY overrides ALLOW |
+| _comment | string | No | No | - |
+
+### State - stateType Constraint
+
+| Constraint | stateType = 5 (Wizard) | All Others |
+|------------|:----------------------:|:----------:|
+| transitions | max 1 item | no limit |
+
+---
+
+## State Transition - triggerType Constraint Matrix
+
+Discriminator: `triggerType` (with `triggerKind` sub-discriminator for Auto)
+
+| Field | Manual (0) | Auto (1) | Auto Default (1+kind:10) | Scheduled (2) | Event (3) |
+|-------|:----------:|:--------:|:------------------------:|:--------------:|:---------:|
+| **key** | **Required** | **Required** | **Required** | **Required** | **Required** |
+| **target** | **Required** | **Required** | **Required** | **Required** | **Required** |
+| **versionStrategy** | **Required** | **Required** | **Required** | **Required** | **Required** |
+| **triggerType** | **Required** (=0) | **Required** (=1) | **Required** (=1) | **Required** (=2) | **Required** (=3) |
+| **labels** | **Required** | **Required** | **Required** | **Required** | **Required** |
+| triggerKind | Optional | Optional | **Required** (=10) | Optional | Optional |
+| rule | null | **Required** (scriptCode) | Optional/null | null | null |
+| timer | null | null | null | **Required** (scriptCode) | null |
+| view | Optional/null (viewDefinition) | null | null | null | null |
+| schema | Optional/null | null | null | null | Optional/null |
+| mapping | Optional/null | null | null | null | Optional/null |
+| onExecutionTasks | Optional | Optional | Optional | Optional | Optional |
+| roles | Optional | Optional | Optional | Optional | Optional |
+| annotations | Optional/null | Optional/null | Optional/null | Optional/null | Optional/null |
+| from | Optional | Optional | Optional | Optional | Optional |
+| _comment | Optional | Optional | Optional | Optional | Optional |
+
+**Notes:**
+- Auto (1): `rule` is a mandatory scriptCode (routing logic)
+- Auto Default (1+kind:10): `rule` is optional (default auto path, no routing needed)
+- Manual (0): `view` supports both single and rule-based viewDefinition
+- `additionalProperties` is **not** restricted (open schema)
+
+---
+
+## Shared Transition - triggerType Constraint Matrix
+
+Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
+
+| Field | Manual (0) | Scheduled (2) | Event (3) |
+|-------|:----------:|:-------------:|:---------:|
+| **key** | **Required** | **Required** | **Required** |
+| **target** | **Required** | **Required** | **Required** |
+| **versionStrategy** | **Required** | **Required** | **Required** |
+| **triggerType** | **Required** (=0) | **Required** (=2) | **Required** (=3) |
+| **labels** | **Required** | **Required** | **Required** |
+| availableIn | Optional | null | null |
+| rule | null | null | null |
+| timer | null | **Required** (scriptCode) | null |
+| view | Optional/null (viewDefinition) | null | null |
+| schema | Optional/null | null | Optional/null |
+| mapping | Optional/null | null | Optional/null |
+| onExecutionTasks | Optional | Optional | Optional |
+| roles | Optional | Optional | Optional |
+| annotations | Optional/null | Optional/null | Optional/null |
+| from | Optional | Optional | Optional |
+| _comment | Optional | Optional | Optional |
+
+**Notes:**
+- Auto (1) is **not supported** -- `triggerType` enum is `[0, 2, 3]`
+- `triggerKind` is **not available** in shared transitions
+- Manual (0): `availableIn` specifies which states this transition applies to
+- Scheduled/Event: `availableIn` must be null (applies globally)
+- `additionalProperties` is **not** restricted (open schema)
+
+---
+
+## startTransition (Manual Only)
+
+`additionalProperties: false` -- only listed fields are allowed.
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | `^[a-z0-9-]+$` |
+| target | string | Yes | No | `^[a-z0-9-]+$` (must point to Initial state) |
+| triggerType | integer | Yes | No | **const: 0** (Manual only) |
+| versionStrategy | versionStrategy | Yes | No | enum |
+| labels | languageLabel[] | Yes | No | minItems: 1 |
+| schema | reference | No | Yes | Data schema for start |
+| mapping | scriptCode | No | Yes | Input mapping |
+| onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| roles | roleGrant[] | No | No | Authorization roles |
+| annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
+
+**Not available:** view, rule, timer, from, availableIn, triggerKind
+
+---
+
+## cancelTransition (Manual Only)
+
+`additionalProperties: false` -- only listed fields are allowed.
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | `^[a-z0-9-]+$` |
+| target | string | Yes | No | `^(\$self\|[a-z0-9-]+)$` |
+| triggerType | integer | Yes | No | **const: 0** (Manual only) |
+| versionStrategy | versionStrategy | Yes | No | enum |
+| labels | languageLabel[] | Yes | No | - |
+| schema | reference | No | Yes | Data schema for cancel |
+| view | viewDefinition | No | Yes | Single or rule-based |
+| mapping | scriptCode | No | Yes | Input mapping |
+| onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| roles | roleGrant[] | No | No | Authorization roles |
+| availableIn | string[] | No | No | States where cancel is available |
+| from | string | No | No | `^[a-z0-9-]+$` |
+| annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
+| _comment | string | No | No | - |
+
+**Not available:** rule, timer, triggerKind
+
+---
+
+## exitTransition (Manual Only)
+
+`additionalProperties: false` -- only listed fields are allowed.
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | `^[a-z0-9-]+$` |
+| target | string | Yes | No | `^(\$self\|[a-z0-9-]+)$` |
+| triggerType | integer | Yes | No | **const: 0** (Manual only) |
+| versionStrategy | versionStrategy | Yes | No | enum |
+| labels | languageLabel[] | Yes | No | - |
+| schema | reference | No | Yes | Data schema for exit |
+| view | viewDefinition | No | Yes | Single or rule-based |
+| mapping | scriptCode | No | Yes | Input mapping |
+| onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| roles | roleGrant[] | No | No | Authorization roles |
+| availableIn | string[] | No | No | States where exit is available |
+| from | string | No | No | `^[a-z0-9-]+$` |
+| annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
+| _comment | string | No | No | - |
+
+**Not available:** rule, timer, triggerKind
+
+---
+
+## updateDataTransition (Manual Only)
+
+`additionalProperties: false` -- only listed fields are allowed.
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| key | string | Yes | No | `^[a-z0-9-]+$` |
+| target | string | Yes | No | **const: `$self`** |
+| triggerType | integer | Yes | No | **const: 0** (Manual only) |
+| versionStrategy | versionStrategy | Yes | No | enum |
+| labels | languageLabel[] | Yes | No | - |
+| schema | reference | No | Yes | Data schema for update |
+| view | viewDefinition | No | Yes | Single or rule-based |
+| mapping | scriptCode | No | Yes | Input mapping |
+| onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| roles | roleGrant[] | No | No | Authorization roles |
+| availableIn | string[] | No | No | States where update is available |
+| from | string | No | No | `^[a-z0-9-]+$` |
+| annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
+| _comment | string | No | No | - |
+
+**Unique constraint:** `target` is always `$self` -- update data never changes state.
+
+**Not available:** rule, timer, triggerKind
+
+---
+
+## Transition Type Comparison Matrix
+
+Summary of all 6 transition types side by side:
+
+| Capability | State Transition | Shared Transition | startTransition | cancelTransition | exitTransition | updateDataTransition |
+|------------|:----------------:|:-----------------:|:---------------:|:----------------:|:--------------:|:--------------------:|
+| triggerType: Manual (0) | Yes | Yes | **Only** | **Only** | **Only** | **Only** |
+| triggerType: Auto (1) | Yes | No | No | No | No | No |
+| triggerType: Scheduled (2) | Yes | Yes | No | No | No | No |
+| triggerType: Event (3) | Yes | Yes | No | No | No | No |
+| target: any state | Yes | Yes | Yes | Yes | Yes | No |
+| target: `$self` | Yes | Yes | No | Yes | Yes | **Only** |
+| view | Manual only | Manual only | No | Yes | Yes | Yes |
+| rule | Auto required | No | No | No | No | No |
+| timer | Scheduled required | Scheduled required | No | No | No | No |
+| triggerKind | Yes | No | No | No | No | No |
+| availableIn | No | Manual only | No | Optional | Optional | Optional |
+| schema | Manual/Event | Manual/Event | Optional | Optional | Optional | Optional |
+| mapping | Manual/Event | Manual/Event | Optional | Optional | Optional | Optional |
+| onExecutionTasks | Optional | Optional | Optional | Optional | Optional | Optional |
+| roles | Optional | Optional | Optional | Optional | Optional | Optional |
+| annotations | Optional | Optional | Optional | Optional | Optional | Optional |
+| additionalProperties | open | open | **false** | **false** | **false** | **false** |
+
+---
+
+## viewDefinition
+
+Supports two formats (or null):
+
+### Single View
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| view | reference | Yes | View component reference |
+| extensions | string[] | No | Extension identifiers |
+| loadData | boolean | No | Whether to load data |
+
+`additionalProperties: false`
+
+### Rule-Based View
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| rules | viewRule[] | Yes | minItems: 1. Evaluated in order, first match wins |
+| default | object | No | Fallback view when no rule matches |
+| default.view | reference | Yes (if default) | Fallback view reference |
+| default.extensions | string[] | No | Fallback extensions |
+| default.loadData | boolean | No | Fallback load data flag |
+
+`additionalProperties: false`
+
+### viewRule
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| rule | scriptCode | Yes | Condition script |
+| view | reference | Yes | View to use when rule matches |
+| extensions | string[] | No | Extension identifiers |
+| loadData | boolean | No | Whether to load data |
+
+`additionalProperties: false`
+
+---
+
+## reference
+
+Two formats (oneOf):
+
+### Explicit Reference
+| Field | Type | Required |
+|-------|------|----------|
+| key | string | Yes (or id) |
+| id | string | Yes (or key) |
+| domain | string | Yes |
+| flow | string | Yes |
+| version | string | Yes |
+
+### Short Reference
+| Field | Type | Required |
+|-------|------|----------|
+| ref | string | Yes |
+
+`additionalProperties: false`
+
+---
+
+## scriptCode
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| type | enum | No | `G` (Global), `L` (Local). Default: `L` |
+| code | string | Conditional | **Required** when type=`L`. Not required when type=`G` |
+| location | string | No | Script file location |
+| encoding | enum | No | `B64` (Base64), `NAT` (Native). Default: `B64` |
+
+`additionalProperties: false`
+
+---
+
+## onExecuteTask
+
+| Field | Type | Required | Nullable | Constraint |
+|-------|------|----------|----------|------------|
+| order | integer | Yes | No | minimum: 1 |
+| task | reference | Yes | No | Task component reference |
+| mapping | scriptCode | Yes | No | Input/output mapping |
+| errorBoundary | errorBoundary | No | Yes | Task-level error boundary |
+| _comment | string | No | No | - |
+
+---
+
+## subFlow
+
+Nullable (`anyOf: [object, null]`).
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| type | enum | Yes | `S` (SubFlow), `P` (SubProcess) |
+| process | reference | Yes | SubFlow process reference |
+| mapping | scriptCode | Yes | Data mapping |
+| viewOverrides | object | No | Dictionary: key (kebab-case) -> reference |
+| overrides | subFlowOverrides | No | Unified overrides (views, transitions, states, timeout) |
+
+`additionalProperties: false`
+
+### subFlowOverrides
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| views | object | No | Dictionary: view key -> reference |
+| transitions | object | No | Dictionary: transition key -> subFlowTransitionOverride |
+| states | object | No | Dictionary: state key -> subFlowStateOverride |
+| timeout | workflowTimeout | No | Timeout override (nullable) |
+
+`additionalProperties: false`
+
+### subFlowTransitionOverride
+| Field | Type | Required |
+|-------|------|----------|
+| roles | roleGrant[] | No |
+
+`additionalProperties: false`
+
+### subFlowStateOverride
+| Field | Type | Required |
+|-------|------|----------|
+| queryRoles | roleGrant[] | No |
+
+`additionalProperties: false`
+
+---
+
+## workflowTimeout
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| key | string | Yes | `^[a-z0-9-]+$` |
+| target | string | Yes | `^(\$self\|[a-z0-9-]+)$` |
+| versionStrategy | versionStrategy | Yes | enum |
+| timer | timerConfig | Yes | ISO 8601 duration |
+| mapping | scriptCode | No | Nullable. Dynamic timeout calculation |
+| _comment | string | No | - |
+
+### timerConfig
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| reset | string | Yes | Timer reset strategy |
+| duration | string | Yes | ISO 8601 duration pattern |
+
+---
+
+## errorBoundary
+
+Used at workflow, state, and task levels.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| onError | errorHandlerRule[] | No | Rules evaluated by priority (lower first) |
+| onTimeout | timeoutPolicy | No | Timeout-specific handling |
+
+### errorHandlerRule
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| action | errorAction | Yes | enum: 0-5 |
+| errorTypes | string[] | No | Exception types to match. `*` = match all |
+| errorCodes | string[] | No | Error codes to match. `*` = match all |
+| transition | string | No | Required for Rollback(2)/Notify(4). Forbidden for Abort(0) |
+| priority | integer | No | minimum: 1, default: 100. Lower = evaluated first |
+| retryPolicy | retryPolicy | No | Required when action=Retry(1) |
+| logOnly | boolean | No | default: false |
+
+**Conditional:** When `action=0` (Abort), `transition` must have maxLength: 0 (empty/absent).
+
+### timeoutPolicy
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| action | errorAction | No | enum: 0-5 |
+| defaultRetryPolicy | retryPolicy | No | Required when action=Retry(1) |
+| transition | string | No | Must reference valid state key. Forbidden for Abort(0) |
+
+**Conditional:** When `action=0` (Abort), `transition` must have maxLength: 0.
+
+### retryPolicy
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| initialDelay | string | Yes | ISO 8601 duration, must be > 0 |
+| maxRetries | integer | No | minimum: 0, default: 3 |
+| backoffType | backoffType | No | enum: 0 (Fixed), 1 (Exponential). Default: 1 |
+| backoffMultiplier | number | No | minimum: 1, default: 2.0 |
+| maxDelay | string | No | ISO 8601 duration, >= initialDelay |
+| useJitter | boolean | No | default: true |
+
+---
+
+## roleGrant
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| role | string | Yes | Role name |
+| grant | enum | Yes | `allow`, `deny`. DENY always overrides ALLOW |
+
+`additionalProperties: false`
+
+---
+
+## languageLabel
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| label | string | Yes | Label text |
+| language | string | Yes | `^[a-z]{2}(-[A-Z]{2})?$` (ISO 639-1) |
+
+---
+
+## Cross-References
+
+| Referenced Component | Used In |
+|---------------------|---------|
+| view-definition | state.view, transition.view, sharedTransition.view, cancelTransition.view, exitTransition.view, updateDataTransition.view, viewRule.view |
+| task-definition | onExecuteTask.task |
+| schema-definition | startTransition.schema, transition.schema, cancelTransition.schema, exitTransition.schema, updateDataTransition.schema, attributes.schema.schema |
+| function-definition | attributes.functions[] |
+| extension-definition | attributes.extensions[], attributes.features[] |

--- a/docs/feature-catalogs/feature-matrix.md
+++ b/docs/feature-catalogs/feature-matrix.md
@@ -1,0 +1,456 @@
+# vNext Feature Catalog Matrix
+> Generated from `features.json` (schema version 1.0.0)  
+> Date: 2026-05-13
+
+## Component Overview
+
+| Component | Fields | Earliest Since | Latest Since |
+|-----------|--------|----------------|---------------|
+| core-header | 48 | 0.0.1 | 0.0.1 |
+| core-schema | 7 | 0.0.1 | 0.0.1 |
+| extension | 17 | 0.0.1 | 0.0.1 |
+| function | 32 | 0.0.1 | 0.0.1 |
+| schema | 33 | 0.0.1 | 0.0.1 |
+| task | 1 | 0.0.1 | 0.0.1 |
+| view | 7 | 0.0.1 | 0.0.1 |
+| workflow | 368 | 0.0.1 | 0.0.44 |
+
+---
+
+## core-header
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| schema | object | 0.0.1 | Yes | - | - |
+| schema.acceptLanguage | string | 0.0.1 | Yes | - | - |
+| schema.actor | object | 0.0.1 | Yes | - | - |
+| schema.actor.consentId | string | 0.0.1 | Yes | - | - |
+| schema.actor.raw | string | 0.0.1 | Yes | - | - |
+| schema.actor.scope | string | 0.0.1 | Yes | - | - |
+| schema.actor.user | string | 0.0.1 | Yes | - | - |
+| schema.client | object | 0.0.1 | Yes | - | - |
+| schema.client.ipAddress | union | 0.0.1 | Yes | - | - |
+| schema.client.port | number | 0.0.1 | Yes | - | - |
+| schema.device | object | 0.0.1 | Yes | - | - |
+| schema.device.deviceId | string | 0.0.1 | Yes | - | - |
+| schema.device.installationId | string | 0.0.1 | Yes | - | - |
+| schema.device.raw | string | 0.0.1 | Yes | - | - |
+| schema.geolocation | object | 0.0.1 | Yes | - | - |
+| schema.geolocation.accuracy | number | 0.0.1 | Yes | - | - |
+| schema.geolocation.altitude | number | 0.0.1 | Yes | - | - |
+| schema.geolocation.latitude | number | 0.0.1 | Yes | - | - |
+| schema.geolocation.longitude | number | 0.0.1 | Yes | - | - |
+| schema.geolocation.timestamp | string | 0.0.1 | Yes | - | - |
+| schema.ifNoneMatch | string | 0.0.1 | Yes | - | - |
+| schema.requestSource | object | 0.0.1 | Yes | - | - |
+| schema.requestSource.componentType | enum | 0.0.1 | Yes | - | router-navigation (0.0.1), workflow-transition (0.0.1), dynamic-view-render (0.0.1), static-view-load (0.0.1), webview-request (0.0.1) (+5 more) |
+| schema.requestSource.raw | string | 0.0.1 | Yes | - | - |
+| schema.requestSource.targetInfo | string | 0.0.1 | Yes | - | - |
+| schema.requestTimestamp | string | 0.0.1 | Yes | - | - |
+| schema.serverTimestamp | string | 0.0.1 | Yes | - | - |
+| schema.traceparent | object | 0.0.1 | Yes | - | - |
+| schema.traceparent.parentId | string | 0.0.1 | Yes | - | - |
+| schema.traceparent.raw | string | 0.0.1 | Yes | - | - |
+| schema.traceparent.traceFlags | string | 0.0.1 | Yes | - | - |
+| schema.traceparent.traceId | string | 0.0.1 | Yes | - | - |
+| schema.traceparent.version | string | 0.0.1 | Yes | - | - |
+| schema.userAgent | object | 0.0.1 | Yes | - | - |
+| schema.userAgent.applicationName | string | 0.0.1 | Yes | - | - |
+| schema.userAgent.deviceInfo | string | 0.0.1 | Yes | - | - |
+| schema.userAgent.engine | string | 0.0.1 | Yes | - | - |
+| schema.userAgent.platform | string | 0.0.1 | Yes | - | - |
+| schema.userAgent.raw | string | 0.0.1 | Yes | - | - |
+| schema.userAgent.version | string | 0.0.1 | Yes | - | - |
+| schema.workflow | object | 0.0.1 | Yes | - | - |
+| schema.workflow.domain | string | 0.0.1 | Yes | - | - |
+| schema.workflow.instanceId | string | 0.0.1 | Yes | - | - |
+| schema.workflow.raw | string | 0.0.1 | Yes | - | - |
+| schema.workflow.runtimeVersion | enum | 0.0.1 | Yes | - | Legacy workflow engine (0.0.1), vNext workflow engine (0.0.1) |
+| schema.workflow.workflow | string | 0.0.1 | Yes | - | - |
+| schema.workflow.workflowVersion | string | 0.0.1 | Yes | - | - |
+| type | string | 0.0.1 | Yes | - | - |
+
+---
+
+## core-schema
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| attributes | object | 0.0.1 | Yes | - | - |
+| domain | string | 0.0.1 | Yes | - | - |
+| flow | string | 0.0.1 | Yes | - | - |
+| flowVersion | string | 0.0.1 | Yes | - | - |
+| key | string | 0.0.1 | Yes | - | - |
+| tags | array | 0.0.1 | Yes | - | - |
+| version | string | 0.0.1 | Yes | - | - |
+
+---
+
+## extension
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| labels | array | 0.0.1 | Yes | - | - |
+| labels[].label | string | 0.0.1 | Yes | - | - |
+| labels[].language | string | 0.0.1 | Yes | - | - |
+| scope | union | 0.0.1 | Yes | - | - |
+| task | object | 0.0.1 | Yes | - | - |
+| task.mapping | object | 0.0.1 | Yes | - | - |
+| task.mapping.code | string | 0.0.1 | Yes | - | - |
+| task.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| task.mapping.location | string | 0.0.1 | Yes | - | - |
+| task.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| task.order | number | 0.0.1 | Yes | - | - |
+| task.task | union | 0.0.1 | Yes | - | - |
+| task.task.domain | string | 0.0.1 | Yes | - | - |
+| task.task.flow | string | 0.0.1 | Yes | - | - |
+| task.task.key | string | 0.0.1 | Yes | - | - |
+| task.task.version | string | 0.0.1 | Yes | - | - |
+| type | union | 0.0.1 | Yes | - | - |
+
+---
+
+## function
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| labels | array | 0.0.1 | Yes | - | - |
+| labels[].label | string | 0.0.1 | Yes | - | - |
+| labels[].language | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks | array | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].mapping | object | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].mapping.code | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| onExecutionTasks[].mapping.location | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| onExecutionTasks[].order | number | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].task | union | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].task.domain | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].task.flow | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].task.key | string | 0.0.1 | Yes | - | - |
+| onExecutionTasks[].task.version | string | 0.0.1 | Yes | - | - |
+| output | unknown | 0.0.1 | Yes | - | - |
+| roles | array | 0.0.1 | Yes | - | - |
+| roles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| roles[].role | string | 0.0.1 | Yes | - | - |
+| scope | enum | 0.0.1 | Yes | - | Domain (0.0.1), Flow (0.0.1), Instance (0.0.1) |
+| task | object | 0.0.1 | Yes | - | - |
+| task.mapping | object | 0.0.1 | Yes | - | - |
+| task.mapping.code | string | 0.0.1 | Yes | - | - |
+| task.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| task.mapping.location | string | 0.0.1 | Yes | - | - |
+| task.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| task.order | number | 0.0.1 | Yes | - | - |
+| task.task | union | 0.0.1 | Yes | - | - |
+| task.task.domain | string | 0.0.1 | Yes | - | - |
+| task.task.flow | string | 0.0.1 | Yes | - | - |
+| task.task.key | string | 0.0.1 | Yes | - | - |
+| task.task.version | string | 0.0.1 | Yes | - | - |
+
+---
+
+## schema
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| labels | array | 0.0.1 | Yes | - | - |
+| labels[].label | string | 0.0.1 | Yes | - | - |
+| labels[].language | string | 0.0.1 | Yes | - | - |
+| schema | object | 0.0.1 | Yes | - | - |
+| schema.$id | string | 0.0.1 | Yes | - | - |
+| schema.$ref | string | 0.0.1 | Yes | - | - |
+| schema.additionalProperties | boolean | 0.0.1 | Yes | - | - |
+| schema.allOf | array | 0.0.1 | Yes | - | - |
+| schema.anyOf | array | 0.0.1 | Yes | - | - |
+| schema.const | unknown | 0.0.1 | Yes | - | - |
+| schema.default | unknown | 0.0.1 | Yes | - | - |
+| schema.description | string | 0.0.1 | Yes | - | - |
+| schema.else | unknown | 0.0.1 | Yes | - | - |
+| schema.enum | array | 0.0.1 | Yes | - | - |
+| schema.examples | array | 0.0.1 | Yes | - | - |
+| schema.format | string | 0.0.1 | Yes | - | - |
+| schema.if | unknown | 0.0.1 | Yes | - | - |
+| schema.items | unknown | 0.0.1 | Yes | - | - |
+| schema.maxItems | number | 0.0.1 | Yes | - | - |
+| schema.maxLength | number | 0.0.1 | Yes | - | - |
+| schema.maximum | number | 0.0.1 | Yes | - | - |
+| schema.minItems | number | 0.0.1 | Yes | - | - |
+| schema.minLength | number | 0.0.1 | Yes | - | - |
+| schema.minimum | number | 0.0.1 | Yes | - | - |
+| schema.oneOf | array | 0.0.1 | Yes | - | - |
+| schema.pattern | string | 0.0.1 | Yes | - | - |
+| schema.properties | object | 0.0.1 | Yes | - | - |
+| schema.required | array | 0.0.1 | Yes | - | - |
+| schema.then | unknown | 0.0.1 | Yes | - | - |
+| schema.title | string | 0.0.1 | Yes | - | - |
+| schema.type | enum | 0.0.1 | Yes | - | object (0.0.1), array (0.0.1), string (0.0.1), number (0.0.1), integer (0.0.1) (+2 more) |
+| schema.uniqueItems | boolean | 0.0.1 | Yes | - | - |
+| type | enum | 0.0.1 | Yes | - | Workflow component definition (0.0.1), Task component definition (0.0.1), Function component definition (0.0.1), View component definition (0.0.1), Schema component definition (0.0.1) (+2 more) |
+
+---
+
+## task
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| type | enum | 0.0.1 | Yes | - | Dapr HTTP Endpoint (0.0.1), Dapr Binding (0.0.1), Dapr Service (0.0.1), Dapr PubSub (0.0.1), Human Task (0.0.1) (+10 more) |
+
+---
+
+## view
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| content | unknown | 0.0.1 | Yes | - | - |
+| display | union | 0.0.1 | Yes | - | - |
+| labels | array | 0.0.1 | Yes | - | - |
+| labels[].label | string | 0.0.1 | Yes | - | - |
+| labels[].language | string | 0.0.1 | Yes | - | - |
+| renderer | enum | 0.0.1 | Yes | - | pseudo-ui (0.0.1), flutter (0.0.1), angular (0.0.1), vue (0.0.1), react (0.0.1) (+3 more) |
+| type | union | 0.0.1 | Yes | - | - |
+
+---
+
+## workflow
+
+| Field | Type | Since | Stable | Experimental | Enum Values |
+|-------|------|-------|--------|--------------|-------------|
+| cancel | object | 0.0.44 | Yes | - | - |
+| cancel.annotations | object | 0.0.42 | Yes | - | - |
+| cancel.availableIn | array | 0.0.1 | Yes | - | - |
+| cancel.from | string | 0.0.1 | Yes | - | - |
+| cancel.key | string | 0.0.1 | Yes | - | - |
+| cancel.labels | array | 0.0.1 | Yes | - | - |
+| cancel.labels[].label | string | 0.0.1 | Yes | - | - |
+| cancel.labels[].language | string | 0.0.1 | Yes | - | - |
+| cancel.mapping | object | 0.0.1 | Yes | - | - |
+| cancel.mapping.code | string | 0.0.1 | Yes | - | - |
+| cancel.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| cancel.mapping.location | string | 0.0.1 | Yes | - | - |
+| cancel.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| cancel.onExecutionTasks | array | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].mapping | object | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].mapping.code | string | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| cancel.onExecutionTasks[].mapping.location | string | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| cancel.onExecutionTasks[].order | number | 0.0.1 | Yes | - | - |
+| cancel.onExecutionTasks[].task | union | 0.0.1 | Yes | - | - |
+| cancel.roles | array | 0.0.1 | Yes | - | - |
+| cancel.roles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| cancel.roles[].role | string | 0.0.1 | Yes | - | - |
+| cancel.schema | union | 0.0.1 | Yes | - | - |
+| cancel.target | string | 0.0.1 | Yes | - | - |
+| cancel.triggerType | number | 0.0.1 | Yes | - | - |
+| cancel.versionStrategy | enum | 0.0.1 | Yes | - | - |
+| cancel.view | union | 0.0.1 | Yes | - | - |
+| errorBoundary | object | 0.0.39 | Yes | - | - |
+| errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].action | enum | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].errorCodes | array | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].errorTypes | array | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].logOnly | boolean | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].priority | number | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy | object | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.backoffMultiplier | number | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.backoffType | enum | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.initialDelay | string | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.maxDelay | string | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.maxRetries | number | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].retryPolicy.useJitter | boolean | 0.0.1 | Yes | - | - |
+| errorBoundary.onError[].transition | string | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.action | enum | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy | object | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.backoffMultiplier | number | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.backoffType | enum | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.initialDelay | string | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.maxDelay | string | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.maxRetries | number | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.defaultRetryPolicy.useJitter | boolean | 0.0.1 | Yes | - | - |
+| errorBoundary.onTimeout.transition | string | 0.0.1 | Yes | - | - |
+| exit | object | 0.0.44 | Yes | - | - |
+| exit.annotations | object | 0.0.42 | Yes | - | - |
+| exit.availableIn | array | 0.0.1 | Yes | - | - |
+| exit.from | string | 0.0.1 | Yes | - | - |
+| exit.key | string | 0.0.1 | Yes | - | - |
+| exit.labels | array | 0.0.1 | Yes | - | - |
+| exit.labels[].label | string | 0.0.1 | Yes | - | - |
+| exit.labels[].language | string | 0.0.1 | Yes | - | - |
+| exit.mapping | object | 0.0.1 | Yes | - | - |
+| exit.mapping.code | string | 0.0.1 | Yes | - | - |
+| exit.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| exit.mapping.location | string | 0.0.1 | Yes | - | - |
+| exit.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| exit.onExecutionTasks | array | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].mapping | object | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].mapping.code | string | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| exit.onExecutionTasks[].mapping.location | string | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| exit.onExecutionTasks[].order | number | 0.0.1 | Yes | - | - |
+| exit.onExecutionTasks[].task | union | 0.0.1 | Yes | - | - |
+| exit.roles | array | 0.0.1 | Yes | - | - |
+| exit.roles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| exit.roles[].role | string | 0.0.1 | Yes | - | - |
+| exit.schema | union | 0.0.1 | Yes | - | - |
+| exit.target | string | 0.0.1 | Yes | - | - |
+| exit.triggerType | number | 0.0.1 | Yes | - | - |
+| exit.versionStrategy | enum | 0.0.1 | Yes | - | - |
+| exit.view | union | 0.0.1 | Yes | - | - |
+| extensions | array | 0.0.1 | Yes | - | - |
+| features | array | 0.0.1 | Yes | - | - |
+| functions | array | 0.0.1 | Yes | - | - |
+| labels | array | 0.0.1 | Yes | - | - |
+| labels[].label | string | 0.0.1 | Yes | - | - |
+| labels[].language | string | 0.0.1 | Yes | - | - |
+| queryRoles | array | 0.0.1 | Yes | - | - |
+| queryRoles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| queryRoles[].role | string | 0.0.1 | Yes | - | - |
+| schema | object | 0.0.1 | Yes | - | - |
+| schema.schema | union | 0.0.1 | Yes | - | - |
+| sharedTransitions | array | 0.0.1 | Yes | - | - |
+| startTransition | object | 0.0.1 | Yes | - | - |
+| startTransition.annotations | object | 0.0.42 | Yes | - | - |
+| startTransition.key | string | 0.0.1 | Yes | - | - |
+| startTransition.labels | array | 0.0.1 | Yes | - | - |
+| startTransition.labels[].label | string | 0.0.1 | Yes | - | - |
+| startTransition.labels[].language | string | 0.0.1 | Yes | - | - |
+| startTransition.mapping | object | 0.0.1 | Yes | - | - |
+| startTransition.mapping.code | string | 0.0.1 | Yes | - | - |
+| startTransition.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| startTransition.mapping.location | string | 0.0.1 | Yes | - | - |
+| startTransition.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| startTransition.onExecutionTasks | array | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].mapping | object | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].mapping.code | string | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| startTransition.onExecutionTasks[].mapping.location | string | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| startTransition.onExecutionTasks[].order | number | 0.0.1 | Yes | - | - |
+| startTransition.onExecutionTasks[].task | union | 0.0.1 | Yes | - | - |
+| startTransition.roles | array | 0.0.1 | Yes | - | - |
+| startTransition.roles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| startTransition.roles[].role | string | 0.0.1 | Yes | - | - |
+| startTransition.schema | union | 0.0.1 | Yes | - | - |
+| startTransition.target | string | 0.0.1 | Yes | - | - |
+| startTransition.triggerType | number | 0.0.1 | Yes | - | - |
+| startTransition.versionStrategy | enum | 0.0.1 | Yes | - | - |
+| states | array | 0.0.1 | Yes | - | - |
+| states[].errorBoundary | object | 0.0.39 | Yes | - | - |
+| states[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].action | enum | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].errorCodes | array | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].errorTypes | array | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].logOnly | boolean | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].priority | number | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].retryPolicy | object | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onError[].transition | string | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onTimeout.action | enum | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onTimeout.defaultRetryPolicy | object | 0.0.1 | Yes | - | - |
+| states[].errorBoundary.onTimeout.transition | string | 0.0.1 | Yes | - | - |
+| states[].key | string | 0.0.1 | Yes | - | - |
+| states[].labels | array | 0.0.1 | Yes | - | - |
+| states[].labels[].label | string | 0.0.1 | Yes | - | - |
+| states[].labels[].language | string | 0.0.1 | Yes | - | - |
+| states[].onEntries | array | 0.0.1 | Yes | - | - |
+| states[].onEntries[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| states[].onEntries[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| states[].onEntries[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| states[].onEntries[].mapping | object | 0.0.1 | Yes | - | - |
+| states[].onEntries[].mapping.code | string | 0.0.1 | Yes | - | - |
+| states[].onEntries[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| states[].onEntries[].mapping.location | string | 0.0.1 | Yes | - | - |
+| states[].onEntries[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| states[].onEntries[].order | number | 0.0.1 | Yes | - | - |
+| states[].onEntries[].task | union | 0.0.1 | Yes | - | - |
+| states[].onExits | array | 0.0.1 | Yes | - | - |
+| states[].onExits[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| states[].onExits[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| states[].onExits[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| states[].onExits[].mapping | object | 0.0.1 | Yes | - | - |
+| states[].onExits[].mapping.code | string | 0.0.1 | Yes | - | - |
+| states[].onExits[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| states[].onExits[].mapping.location | string | 0.0.1 | Yes | - | - |
+| states[].onExits[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| states[].onExits[].order | number | 0.0.1 | Yes | - | - |
+| states[].onExits[].task | union | 0.0.1 | Yes | - | - |
+| states[].queryRoles | array | 0.0.1 | Yes | - | - |
+| states[].queryRoles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| states[].queryRoles[].role | string | 0.0.1 | Yes | - | - |
+| states[].stateType | enum | 0.0.1 | Yes | - | - |
+| states[].subFlow | object | 0.0.1 | Yes | - | - |
+| states[].subType | enum | 0.0.1 | Yes | - | - |
+| states[].transitions | array | 0.0.1 | Yes | - | - |
+| states[].versionStrategy | enum | 0.0.1 | Yes | - | - |
+| states[].view | union | 0.0.1 | Yes | - | - |
+| timeout | object | 0.0.1 | Yes | - | - |
+| timeout.key | string | 0.0.1 | Yes | - | - |
+| timeout.mapping | object | 0.0.1 | Yes | - | - |
+| timeout.mapping.code | string | 0.0.1 | Yes | - | - |
+| timeout.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| timeout.mapping.location | string | 0.0.1 | Yes | - | - |
+| timeout.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| timeout.target | string | 0.0.1 | Yes | - | - |
+| timeout.timer | object | 0.0.1 | Yes | - | - |
+| timeout.timer.duration | string | 0.0.1 | Yes | - | - |
+| timeout.timer.reset | string | 0.0.1 | Yes | - | - |
+| timeout.versionStrategy | enum | 0.0.1 | Yes | - | - |
+| type | enum | 0.0.1 | Yes | - | Core (0.0.1), Flow (0.0.1), SubFlow (0.0.1), Sub Process (0.0.1) |
+| updateData | object | 0.0.44 | Yes | - | - |
+| updateData.annotations | object | 0.0.42 | Yes | - | - |
+| updateData.availableIn | array | 0.0.1 | Yes | - | - |
+| updateData.from | string | 0.0.1 | Yes | - | - |
+| updateData.key | string | 0.0.1 | Yes | - | - |
+| updateData.labels | array | 0.0.1 | Yes | - | - |
+| updateData.labels[].label | string | 0.0.1 | Yes | - | - |
+| updateData.labels[].language | string | 0.0.1 | Yes | - | - |
+| updateData.mapping | object | 0.0.1 | Yes | - | - |
+| updateData.mapping.code | string | 0.0.1 | Yes | - | - |
+| updateData.mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| updateData.mapping.location | string | 0.0.1 | Yes | - | - |
+| updateData.mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| updateData.onExecutionTasks | array | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].errorBoundary | object | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].errorBoundary.onError | array | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].errorBoundary.onTimeout | object | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].mapping | object | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].mapping.code | string | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].mapping.encoding | enum | 0.0.1 | Yes | - | B64 (0.0.1), NAT (0.0.1) |
+| updateData.onExecutionTasks[].mapping.location | string | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].mapping.type | enum | 0.0.1 | Yes | - | Global (0.0.1), Local (0.0.1) |
+| updateData.onExecutionTasks[].order | number | 0.0.1 | Yes | - | - |
+| updateData.onExecutionTasks[].task | union | 0.0.1 | Yes | - | - |
+| updateData.roles | array | 0.0.1 | Yes | - | - |
+| updateData.roles[].grant | enum | 0.0.1 | Yes | - | allow (0.0.1), deny (0.0.1) |
+| updateData.roles[].role | string | 0.0.1 | Yes | - | - |
+| updateData.schema | union | 0.0.1 | Yes | - | - |
+| updateData.target | string | 0.0.1 | Yes | - | - |
+| updateData.triggerType | number | 0.0.1 | Yes | - | - |
+| updateData.versionStrategy | enum | 0.0.1 | Yes | - | - |
+| updateData.view | union | 0.0.1 | Yes | - | - |
+
+### Definitions
+
+| Definition | Type | Since | Values |
+|------------|------|-------|--------|
+| backoffType | enum | 0.0.39 | 0:Fixed - Fixed delay between retries (0.0.39), 1:Exponential - Exponential backoff between retries (0.0.39) |
+| errorAction | enum | 0.0.39 | 0:Abort (0) - Abort execution. Transition must not be set. (0.0.39), 1:Retry (1) - Retry with configured retry policy. RetryPolicy is required. (0.0.39), 2:Rollback (2) - Rollback to compensation state. Transition is required (transition key). (0.0.39), 3:Ignore (3) - Ignore error and continue (0.0.39), 4:Notify (4) - Send notification and transition. Transition is required (transition key). (0.0.42) (+1 more) |
+| stateSubType | enum | 0.0.1 | 0:No specific subtype (0.0.1), 1:Successful completion (0.0.1), 2:Error condition (0.0.1), 3:Manually terminated (0.0.1), 4:Temporarily suspended (0.0.1) (+2 more) |
+| stateType | enum | 0.0.1 | 1:Initial state (0.0.1), 2:Intermediate state (0.0.1), 3:Final state (0.0.1), 4:SubFlow state (0.0.1), 5:Wizard state (0.0.40) |
+| triggerKind | enum | 0.0.1 | 0:Not applicable (0.0.1), 10:Default auto transition (0.0.1) |
+| triggerType | enum | 0.0.1 | 0:Manual trigger (0.0.1), 1:Automatic trigger (0.0.1), 2:Scheduled trigger (0.0.40), 3:Event trigger (0.0.42) |
+| versionStrategy | enum | 0.0.1 | None:No version update (0.0.1), Patch:Patch version update (0.0.1), Minor:Minor version update (0.0.1), Major:Major version update (0.0.1) |
+
+---
+

--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -533,21 +533,34 @@
                     },
                     "then": {
                         "title": "Notification Task",
+                        "$comment": "since:0.0.42",
                         "properties": {
                             "type": {
                                 "const": "10"
                             },
                             "config": {
                                 "type": "object",
-                                "description": "Notification Binding configuration",
+                                "description": "Notification Task configuration - Multi-channel notification dispatch via Dapr bindings",
                                 "properties": {
-                                    "metadata": {
-                                        "type": "object",
-                                        "description": "Binding metadata"
+                                    "channels": {
+                                        "type": "array",
+                                        "$comment": "since:0.0.42",
+                                        "description": "Target channel list. Each channel resolves to a vnext-notification-{channel} Dapr binding (e.g. sms, email, push, hub, state).",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "minItems": 1
+                                    },
+                                    "includeStateChannel": {
+                                        "type": "boolean",
+                                        "$comment": "since:0.0.42",
+                                        "description": "When true, the platform-managed state channel is automatically included in the dispatch list (uses State Function data, no mapping needed).",
+                                        "default": true
                                     }
                                 },
                                 "required": [
-                                    "metadata"
+                                    "channels"
                                 ],
                                 "additionalProperties": false
                             }

--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -156,6 +156,10 @@
                 "_comment": {
                     "type": "string",
                     "description": "Comment about the view"
+                },
+                "renderer": {
+                    "type": "string",
+                    "description": "Renderer identifier for the view"
                 }
             },
             "allOf": [
@@ -187,6 +191,17 @@
                                 "type": "string",
                                 "minLength": 1
                             }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": { "type": { "not": { "const": 1 } } },
+                        "required": ["type"]
+                    },
+                    "then": {
+                        "properties": {
+                            "renderer": false
                         }
                     }
                 }

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -226,7 +226,7 @@
       "additionalProperties": false
     },
     "viewDefinition": {
-      "anyOf": [
+      "oneOf": [
         {
           "type": "object",
           "properties": {
@@ -245,12 +245,75 @@
           },
           "required": [
             "view"
-          ]
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "rules": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/viewRule"
+              },
+              "minItems": 1
+            },
+            "default": {
+              "type": "object",
+              "properties": {
+                "view": {
+                  "$ref": "#/definitions/reference"
+                },
+                "extensions": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "loadData": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "view"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "rules"
+          ],
+          "additionalProperties": false
         },
         {
           "type": "null"
         }
       ]
+    },
+    "viewRule": {
+      "type": "object",
+      "properties": {
+        "rule": {
+          "$ref": "#/definitions/scriptCode"
+        },
+        "view": {
+          "$ref": "#/definitions/reference"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "loadData": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "rule",
+        "view"
+      ],
+      "additionalProperties": false
     },
     "versionStrategy": {
       "type": "string",
@@ -324,7 +387,9 @@
         3,
         4,
         5,
-        6
+        6,
+        7,
+        8
       ],
       "enumDescriptions": [
         "No specific subtype",
@@ -333,7 +398,9 @@
         "Manually terminated",
         "Temporarily suspended",
         "Busy",
-        "Human"
+        "Human",
+        "Cancelled",
+        "Timeout"
       ],
       "description": "Subtype of workflow state",
       "default": 0
@@ -673,6 +740,17 @@
               "items": {
                 "$ref": "#/definitions/roleGrant"
               }
+            },
+            "annotations": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/annotations"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Key-value annotations for the transition"
             }
           }
         },
@@ -868,10 +946,9 @@
               "$ref": "#/definitions/versionStrategy"
             },
             "triggerType": {
-              "$ref": "#/definitions/triggerType"
-            },
-            "triggerKind": {
-              "$ref": "#/definitions/triggerKind"
+              "type": "integer",
+              "enum": [0, 2, 3],
+              "description": "Trigger type for shared transitions: Manual (0), Scheduled (2), Event (3)"
             },
             "availableIn": {
               "type": "array",
@@ -946,80 +1023,17 @@
                 }
               ],
               "description": "Input mapping for the transition"
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "triggerType": {
-                "const": 1
-              },
-              "triggerKind": {
-                "const": 10
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "rule": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/scriptCode"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "timer": {
-                "type": "null"
-              },
-              "schema": {
-                "type": "null"
-              },
-              "view": {
-                "type": "null"
-              },
-              "mapping": {
-                "type": "null"
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "triggerType": {
-                "const": 1
-              }
             },
-            "not": {
-              "properties": {
-                "triggerKind": {
-                  "const": 10
+            "annotations": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/annotations"
+                },
+                {
+                  "type": "null"
                 }
-              }
-            }
-          },
-          "then": {
-            "required": ["rule"],
-            "properties": {
-              "rule": {
-                "$ref": "#/definitions/scriptCode"
-              },
-              "timer": {
-                "type": "null"
-              },
-              "schema": {
-                "type": "null"
-              },
-              "view": {
-                "type": "null"
-              },
-              "mapping": {
-                "type": "null"
-              }
+              ],
+              "description": "Key-value annotations for the transition"
             }
           }
         },
@@ -1083,7 +1097,6 @@
             }
           },
           "then": {
-            "required": ["availableIn"],
             "properties": {
               "availableIn": {
                 "type": "array",
@@ -1093,14 +1106,7 @@
                 }
               },
               "view": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/reference"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "$ref": "#/definitions/viewDefinition"
               }
             }
           },
@@ -1280,6 +1286,17 @@
           "items": {
             "$ref": "#/definitions/roleGrant"
           }
+        },
+        "annotations": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Key-value annotations for the cancel transition"
         }
       },
       "additionalProperties": false
@@ -1373,6 +1390,17 @@
           "items": {
             "$ref": "#/definitions/roleGrant"
           }
+        },
+        "annotations": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Key-value annotations for the exit transition"
         }
       },
       "additionalProperties": false
@@ -1466,6 +1494,17 @@
           "items": {
             "$ref": "#/definitions/roleGrant"
           }
+        },
+        "annotations": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/annotations"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Key-value annotations for the update data transition"
         }
       },
       "additionalProperties": false
@@ -1848,6 +1887,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Key-value annotations for the transition",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
…annels, renderer, and annotations

task: replace notification metadata with channels array and includeStateChannel for multi-channel dispatch (0.0.42). view: add renderer property gated to type=1.
workflow: add rule-based viewDefinition (oneOf), stateSubType 7/8, annotations on all transition types, simplify shared transitions.

Also add cursor rules, skills, and generated documentation.

## Summary by Sourcery

Extend vNext component schemas with richer notification, view, and workflow capabilities and generate corresponding documentation and feature matrices.

New Features:
- Add notification channels configuration and includeStateChannel support to task definitions for multi-channel dispatch.
- Introduce renderer support and rule-based viewDefinition variants in view and workflow schemas.
- Extend workflow transitions and states with annotations, additional state subtypes, and new manual-only transition types (cancel, exit, updateData).

Enhancements:
- Add cursor skills for automatically generating component constraint matrices and feature catalog documentation from schema files.

Documentation:
- Generate workflow constraint matrix documentation and a vNext feature catalog matrix derived from features.json.