### PR TITLE
feat(schemas): add state interaction.longPoll and HTTP task contentType

### DIFF
--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -459,6 +459,10 @@
                                         "type": "object",
                                         "description": "HTTP request body"
                                     },
+                                    "contentType": {
+                                        "type": "string",
+                                        "description": "Content-Type header for the HTTP request body (e.g. application/json)."
+                                    },
                                     "timeoutSeconds": {
                                         "type": "integer",
                                         "minimum": 1,

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1726,6 +1726,17 @@
           "items": {
             "$ref": "#/definitions/stateAlias"
           }
+        },
+        "interaction": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/interaction"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional state interaction configuration (e.g. long polling)."
         }
       }
     },
@@ -2072,6 +2083,43 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "interaction": {
+      "type": "object",
+      "description": "State interaction configuration.",
+      "properties": {
+        "longPoll": {
+          "$ref": "#/definitions/longPoll"
+        }
+      },
+      "additionalProperties": false
+    },
+    "longPoll": {
+      "type": "object",
+      "description": "Long polling configuration for the state. The runtime keeps the request open until a transition occurs or the fallback timeout elapses.",
+      "required": [
+        "terminate",
+        "roles"
+      ],
+      "properties": {
+        "terminate": {
+          "type": "boolean",
+          "description": "Whether the long poll terminates the open request when the state is left."
+        },
+        "fallbackTimeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of seconds to hold the request open before falling back."
+        },
+        "roles": {
+          "type": "array",
+          "description": "Roles allowed to use the long poll interaction. DENY overrides ALLOW.",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
## What

Two optional fields the vNext runtime now supports are added to the schemas:

### 1. `workflow-definition.schema.json` — state-level long polling
- New optional `interaction` property on `state` (`anyOf`: `interaction` def or `null`).
- New `interaction` definition: contains only `longPoll`, `additionalProperties: false`.
- New `longPoll` definition:
  - `terminate` (boolean) and `roles` are **required**
  - `fallbackTimeoutSeconds` (integer ≥ 1) is optional
  - `roles` reuses the existing `roleGrant` definition (`{ role, grant }`)

```json
"interaction": {
  "longPoll": {
    "terminate": true,
    "fallbackTimeoutSeconds": 600,
    "roles": [{ "role": "morph-core.maker", "grant": "allow" }]
  }
}
```

### 2. `task-definition.schema.json` — HTTP Task (type 6) `contentType`
- New optional free-string `contentType` under HTTP Task `config` (e.g. `application/json`).
- `required` (`url`, `method`) unchanged.

## Why

The runtime gained support for both fields. Because `config` and the new `interaction` use `additionalProperties: false`, these must be declared in the schema or valid documents would be rejected by `@burgan-tech/vnext-cli`.

## Notes for reviewers

- Both fields are **optional** — existing component JSON is unaffected.
- No changes to `index.js` / `index.d.ts` (schemas are exported as-is).

## Verification

- `npm test` → all schemas valid
- `npm run lint` → clean
- Functional fixture checks (temporary, removed): valid longPoll passes; missing `roles` rejected; unknown `interaction` key rejected; type-6 task with `contentType` passes; unknown config key rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add schema support for new runtime features around state long polling and HTTP task content type.

New Features:
- Introduce an optional state-level interaction.longPoll configuration in the workflow-definition schema to control long polling behavior.
- Allow HTTP task definitions to specify an optional contentType field in their config within the task-definition schema.