### PR TITLE
feat(schemas): add notifications to workflow state definition

### DIFF
--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1737,6 +1737,13 @@
             }
           ],
           "description": "Optional state interaction configuration (e.g. long polling)."
+        },
+        "notifications": {
+          "type": "array",
+          "description": "Notification definitions attached to this state.",
+          "items": {
+            "$ref": "#/definitions/stateNotification"
+          }
         }
       }
     },
@@ -2117,6 +2124,40 @@
           "items": {
             "$ref": "#/definitions/roleGrant"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "stateNotification": {
+      "type": "object",
+      "description": "Notification configuration attached to a state.",
+      "required": [
+        "type",
+        "mapping"
+      ],
+      "properties": {
+        "type": {
+          "type": "integer",
+          "enum": [
+            0
+          ],
+          "enumDescriptions": [
+            "State"
+          ],
+          "description": "Notification type. Currently only State (0) is supported."
+        },
+        "mapping": {
+          "$ref": "#/definitions/scriptCode"
+        },
+        "rule": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/scriptCode"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

- Adds optional `notifications` array property to the `state` definition
- Introduces new `stateNotification` definition in `definitions`
- Each notification has:
  - `type` (required) — integer enum, currently only `0` (State)
  - `mapping` (required) — reuses existing `scriptCode` definition
  - `rule` (optional) — reuses existing `scriptCode` definition
- `additionalProperties: false` consistent with other leaf definitions

## Why

Backend has shipped notification support on states. Schema needs to accept the new field so CLI validation and tooling IntelliSense work correctly.

## Test plan

- [ ] `npm test` passes — AJV compiles the updated schema without errors
- [ ] `npm run lint` passes
- [ ] A state with a valid `notifications` array validates successfully
- [ ] A notification object missing `mapping` fails validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Allow workflow state definitions to include an optional notifications array referencing a new stateNotification schema definition.