### PR TITLE
feat(schemas): add StateStore task type 17 and workflow output mapping

### DIFF
--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -82,7 +82,8 @@
                         "13",
                         "14",
                         "15",
-                        "16"
+                        "16",
+                        "17"
                     ],
                     "enumDescriptions": [
                         "Dapr HTTP Endpoint",
@@ -100,7 +101,8 @@
                         "Get Instance Data Task",
                         "SubProcess Task",
                         "Get Instances Task",
-                        "SOAP Task"
+                        "SOAP Task",
+                        "State Store Task"
                     ]
                 }
             },
@@ -1128,6 +1130,100 @@
                                 },
                                 "required": [
                                     "url"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "config"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "17"
+                            }
+                        }
+                    },
+                    "then": {
+                        "title": "State Store Task",
+                        "properties": {
+                            "type": {
+                                "const": "17"
+                            },
+                            "config": {
+                                "type": "object",
+                                "description": "State Store Task configuration - Accesses a Dapr state store component to cache data within the workflow pipeline",
+                                "properties": {
+                                    "command": {
+                                        "type": "string",
+                                        "enum": [
+                                            "get",
+                                            "set",
+                                            "delete"
+                                        ],
+                                        "description": "Command to execute"
+                                    },
+                                    "storeName": {
+                                        "type": "string",
+                                        "description": "Optional Dapr state store component name. When empty, the executing runtime's DAPR_STATE_STORE_NAME configuration value is used."
+                                    },
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Cache key targeted by get, set and single-key delete"
+                                    },
+                                    "keys": {
+                                        "type": "array",
+                                        "description": "Optional list of keys for bulk delete",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "minItems": 1
+                                    },
+                                    "query": {
+                                        "type": "object",
+                                        "description": "Optional Dapr state Query API filter (JSON) for tag/pattern based delete"
+                                    },
+                                    "value": {
+                                        "description": "Value written by set (any JSON value)"
+                                    },
+                                    "ttlInSeconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "Optional time-to-live in seconds applied on set (Dapr ttlInSeconds metadata)"
+                                    },
+                                    "etag": {
+                                        "type": "string",
+                                        "description": "Optional ETag for optimistic concurrency on read/write"
+                                    },
+                                    "concurrency": {
+                                        "type": "string",
+                                        "enum": [
+                                            "FirstWrite",
+                                            "LastWrite"
+                                        ],
+                                        "description": "Optional concurrency mode"
+                                    },
+                                    "consistency": {
+                                        "type": "string",
+                                        "enum": [
+                                            "Eventual",
+                                            "Strong"
+                                        ],
+                                        "description": "Optional consistency mode"
+                                    },
+                                    "metadata": {
+                                        "type": "object",
+                                        "description": "Optional additional metadata passed to the Dapr state store operation"
+                                    }
+                                },
+                                "required": [
+                                    "command"
                                 ],
                                 "additionalProperties": false
                             }

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -211,6 +211,17 @@
           "items": {
             "$ref": "#/definitions/roleGrant"
           }
+        },
+        "output": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/scriptCode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional output mapping for the workflow. Based on ScriptCode definition."
         }
       }
     }


### PR DESCRIPTION
## What changed

### `schemas/task-definition.schema.json` — new task type 17 (State Store Task)
- Added `"17"` to the `attributes.type` enum with description **State Store Task**.
- Added an `if/then` config block mirroring the runtime's new `BBT.Workflow.Definitions.StateStoreTask` (`Configure()` property names):
  - `command` (**required**, enum: `get` / `set` / `delete`)
  - `storeName` — optional Dapr state store component name (falls back to the runtime's `DAPR_STATE_STORE_NAME`)
  - `key`, `keys` (bulk delete), `query` (Dapr state Query API filter for tag/pattern delete)
  - `value` (any JSON value, written by `set`), `ttlInSeconds` (min 1)
  - `etag`, `concurrency` (`FirstWrite` / `LastWrite`), `consistency` (`Eventual` / `Strong`), `metadata`
- `additionalProperties: false`, consistent with the other task type blocks.

### `schemas/workflow-definition.schema.json` — optional `output` on workflow attributes
- Added `attributes.output` as `anyOf [scriptCode, null]`, following the existing `mapping`/`rule` pattern. Not added to `required` — the field is optional.

## Why

The runtime introduced the StateStore task (TaskType 17) for caching data in the workflow pipeline via Dapr state stores, and a workflow-level `output` mapping based on the ScriptCode definition. The schemas need to recognize both so CLI validation accepts these components.

## Reviewer notes

- Only `command` is required in the type-17 config (no per-command conditional requirements), matching the runtime's `Configure()`, which enforces none, and the simple style of the other task blocks.
- `value` has no type constraint on purpose — it is a `JsonElement` on the C# side and may be any JSON value.
- Verified with `npm test` (all schemas compile) plus ad-hoc AJV checks: valid get/set/delete samples pass; missing `command`, invalid enum values, and unknown config fields are rejected; `output` accepts scriptCode (B64 and REF mapping), `null`, or omission, and rejects scriptCode violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add schema support for the new State Store task type and optional workflow-level output mapping.

New Features:
- Introduce task type 17 (State Store Task) to the task-definition schema, including configuration for Dapr state store operations.
- Add an optional output mapping field to workflow attributes based on the existing scriptCode definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new task type: **State Store Task**.
  * State Store Tasks can now be configured with actions like get, set, and delete, plus options for keys, values, TTL, concurrency, and metadata.
  * Workflows now support an optional output mapping field.

* **Bug Fixes**
  * Expanded schema validation to recognize the new task type and its configuration, helping prevent invalid workflow definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->