### PR TITLE
feat(schemas): CacheAside/GetInstance tasks, event-workflow, function cache, data-vocab

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -279,6 +279,51 @@
                 "rawResponse": {
                     "type": "boolean",
                     "description": "When true, the function returns the task response as-is without wrapping/transformation."
+                },
+                "cache": {
+                    "type": "object",
+                    "description": "Optional read-through cache configuration. When set, the function's response is served from the cache on a hit (tasks skipped) and written to the cache on a miss. Only side-effect-free (read) functions should enable this.",
+                    "properties": {
+                        "keyExpression": {
+                            "description": "Optional Dynamic Expresso expression (a ScriptCode with location 'dynamicExpresso') that computes the cache key from the request/script context and returns a string. Takes precedence over 'key'.",
+                            "allOf": [
+                                { "$ref": "#/definitions/scriptExpression" }
+                            ]
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "Optional static cache key, used when keyExpression is absent."
+                        },
+                        "storeName": {
+                            "type": "string",
+                            "description": "Optional Dapr state store component name. When empty, the executing runtime's DAPR_STATE_STORE_NAME configuration value is used."
+                        },
+                        "ttlInSeconds": {
+                            "type": "integer",
+                            "description": "Optional time-to-live in seconds for the cached response. Null or non-positive means no expiry."
+                        },
+                        "consistency": {
+                            "type": "string",
+                            "enum": ["Eventual", "Strong"],
+                            "description": "Optional consistency mode: Eventual (default) or Strong."
+                        },
+                        "bypassOnCacheError": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "When true (default), cache read/write failures fall back to executing the function instead of failing the request; when false, a cache error surfaces as a failure."
+                        },
+                        "generationKeyExpression": {
+                            "description": "Optional Dynamic Expresso expression resolving to the state key that holds this config's cache generation stamp. When configured, the runtime folds the stamp into the cache key for generation-namespace invalidation. Takes precedence over generationKey.",
+                            "allOf": [
+                                { "$ref": "#/definitions/scriptExpression" }
+                            ]
+                        },
+                        "generationKey": {
+                            "type": "string",
+                            "description": "Optional static state key holding the cache generation stamp (used when generationKeyExpression is absent)."
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false
@@ -414,6 +459,41 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            },
+            "additionalProperties": false
+        },
+        "scriptExpression": {
+            "type": "object",
+            "description": "A ScriptCode expression used by cache key sources. For Dynamic Expresso key expressions, location is 'dynamicExpresso' and code is the expression string.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["G", "L"],
+                    "enumDescriptions": [
+                        "Global",
+                        "Local"
+                    ],
+                    "default": "L",
+                    "description": "Script type - Global or Local"
+                },
+                "location": {
+                    "type": "string",
+                    "description": "Script location. Use 'dynamicExpresso' for Dynamic Expresso expressions."
+                },
+                "code": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Expression or script code content."
+                },
+                "encoding": {
+                    "type": "string",
+                    "description": "Code encoding format",
+                    "enum": ["B64", "NAT", "REF"],
+                    "default": "B64"
+                },
+                "scripts": {
+                    "$ref": "#/definitions/scripts"
                 }
             },
             "additionalProperties": false

--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -83,7 +83,9 @@
                         "14",
                         "15",
                         "16",
-                        "17"
+                        "17",
+                        "18",
+                        "19"
                     ],
                     "enumDescriptions": [
                         "Dapr HTTP Endpoint",
@@ -102,7 +104,9 @@
                         "SubProcess Task",
                         "Get Instances Task",
                         "SOAP Task",
-                        "State Store Task"
+                        "State Store Task",
+                        "Cache Aside Task",
+                        "Get Instance Task"
                     ]
                 }
             },
@@ -1224,6 +1228,262 @@
                                 },
                                 "required": [
                                     "command"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "config"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "18"
+                            }
+                        }
+                    },
+                    "then": {
+                        "title": "Cache Aside Task",
+                        "properties": {
+                            "type": {
+                                "const": "18"
+                            },
+                            "config": {
+                                "type": "object",
+                                "description": "Cache Aside Task configuration - Read-through cache pattern: reads from a Dapr state store, and on a cache miss executes the referenced source task, writes the shaped result back with a TTL, and returns it.",
+                                "properties": {
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Static cache key. Optional - a dynamic key may be derived at runtime via an input mapping or the keyExpression."
+                                    },
+                                    "storeName": {
+                                        "type": "string",
+                                        "description": "Optional Dapr state store component name used as the cache. When empty, the executing runtime's DAPR_STATE_STORE_NAME configuration value is used."
+                                    },
+                                    "ttlInSeconds": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "Time-to-live in seconds for cached entries. When absent or 0, the entry has no expiry."
+                                    },
+                                    "consistency": {
+                                        "type": "string",
+                                        "enum": [
+                                            "Eventual",
+                                            "Strong"
+                                        ],
+                                        "description": "Optional consistency mode passed through to the Dapr state store."
+                                    },
+                                    "sourceTask": {
+                                        "type": "object",
+                                        "description": "Reference to the task executed on a cache miss.",
+                                        "properties": {
+                                            "key": {
+                                                "type": "string",
+                                                "description": "Source task key",
+                                                "minLength": 1
+                                            },
+                                            "domain": {
+                                                "type": "string",
+                                                "description": "Source task domain",
+                                                "minLength": 1
+                                            },
+                                            "flow": {
+                                                "type": "string",
+                                                "description": "Source task flow. Defaults to 'sys-tasks' when omitted."
+                                            },
+                                            "version": {
+                                                "type": "string",
+                                                "description": "Source task version",
+                                                "minLength": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "key",
+                                            "domain",
+                                            "version"
+                                        ],
+                                        "additionalProperties": false
+                                    },
+                                    "sourceMapping": {
+                                        "type": "object",
+                                        "description": "Optional mapping (ScriptCode) applied to the raw source result before it is cached and returned.",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "G",
+                                                    "L"
+                                                ],
+                                                "enumDescriptions": [
+                                                    "Global",
+                                                    "Local"
+                                                ],
+                                                "description": "Script type - Global or Local"
+                                            },
+                                            "code": {
+                                                "type": "string",
+                                                "description": "Script code content"
+                                            },
+                                            "location": {
+                                                "type": "string",
+                                                "description": "Location of the script file"
+                                            },
+                                            "encoding": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "B64",
+                                                    "NAT",
+                                                    "REF"
+                                                ],
+                                                "description": "Code encoding format"
+                                            }
+                                        }
+                                    },
+                                    "keyExpression": {
+                                        "type": "object",
+                                        "description": "Optional Dynamic Expresso expression (ScriptCode with location='dynamicExpresso') whose evaluated string result overrides the cache key at runtime.",
+                                        "properties": {
+                                            "type": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "G",
+                                                    "L"
+                                                ],
+                                                "enumDescriptions": [
+                                                    "Global",
+                                                    "Local"
+                                                ],
+                                                "description": "Script type - Global or Local"
+                                            },
+                                            "code": {
+                                                "type": "string",
+                                                "description": "Script code content"
+                                            },
+                                            "location": {
+                                                "type": "string",
+                                                "description": "Location of the script file"
+                                            },
+                                            "encoding": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "B64",
+                                                    "NAT",
+                                                    "REF"
+                                                ],
+                                                "description": "Code encoding format"
+                                            }
+                                        }
+                                    },
+                                    "bypassOnCacheError": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "When true (default), cache read/write failures fall back to the source task instead of failing the pipeline. When false, cache errors surface as task failure."
+                                    },
+                                    "forceRefresh": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "When true, the cache read is skipped: the source task is always executed and the cache entry overwritten."
+                                    }
+                                },
+                                "required": [
+                                    "sourceTask"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "config"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "19"
+                            }
+                        }
+                    },
+                    "then": {
+                        "title": "Get Instance Task",
+                        "properties": {
+                            "type": {
+                                "const": "19"
+                            },
+                            "config": {
+                                "type": "object",
+                                "description": "Get Instance Task configuration - Retrieves a full workflow instance projection (metadata + data) from a workflow instance.",
+                                "properties": {
+                                    "domain": {
+                                        "type": "string",
+                                        "description": "Target workflow domain",
+                                        "minLength": 1
+                                    },
+                                    "flow": {
+                                        "type": "string",
+                                        "description": "Target workflow name",
+                                        "minLength": 1
+                                    },
+                                    "key": {
+                                        "type": "string",
+                                        "description": "Target instance key"
+                                    },
+                                    "instanceId": {
+                                        "type": "string",
+                                        "description": "Target instance ID (GUID format)",
+                                        "format": "uuid"
+                                    },
+                                    "extensions": {
+                                        "type": "array",
+                                        "description": "Data extensions to include for enrichment",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "useDapr": {
+                                        "type": "boolean",
+                                        "description": "Whether to use Dapr service invocation instead of direct HTTP",
+                                        "default": false
+                                    },
+                                    "headers": {
+                                        "type": "object",
+                                        "description": "HTTP headers"
+                                    },
+                                    "timeoutSeconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "description": "Timeout in seconds"
+                                    },
+                                    "validateSsl": {
+                                        "type": "boolean",
+                                        "description": "Whether to validate SSL certificates"
+                                    },
+                                    "acceptedStatusCodes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "pattern": "^([1-9][0-9]{2}|[1-9]xx|[1-9][0-9]x)$",
+                                            "description": "Exact status code (e.g. '403') or wildcard pattern (e.g. '4xx', '40x')"
+                                        },
+                                        "description": "HTTP status codes treated as successful even when they are error codes. Supports exact codes ('403', '404') and alias patterns ('4xx', '40x', '5xx', '50x'). When a response matches any entry, the task is considered successful and the ErrorBoundary is not triggered.",
+                                        "examples": [
+                                            ["404"],
+                                            ["403", "404"],
+                                            ["4xx"],
+                                            ["403", "5xx"]
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "domain",
+                                    "flow"
                                 ],
                                 "additionalProperties": false
                             }

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -222,6 +222,17 @@
             }
           ],
           "description": "Optional output mapping for the workflow. Based on ScriptCode definition."
+        },
+        "event": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/event"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional workflow-level event definition. When present, an external event may start a new instance of this workflow (action=start). Independent of any transition-level event."
         }
       }
     }
@@ -522,6 +533,19 @@
           "additionalProperties": false
         }
       ]
+    },
+    "event": {
+      "type": "object",
+      "description": "Event mapping for the event-workflow feature. The referenced mapping script (implements IEventMapping) turns the raw external event payload into an InstanceKey + Body.",
+      "required": [
+        "mapping"
+      ],
+      "properties": {
+        "mapping": {
+          "$ref": "#/definitions/scriptCode"
+        }
+      },
+      "additionalProperties": false
     },
     "scriptCode": {
       "type": "object",
@@ -874,6 +898,17 @@
                 }
               ],
               "description": "Key-value annotations for the transition"
+            },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/event"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional transition-level event definition. When present, this transition can also be triggered by an external event (action=transition). Required when triggerType is Event (3)."
             }
           }
         },
@@ -1039,6 +1074,23 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "triggerType": {
+                "const": 3
+              }
+            },
+            "required": [
+              "triggerType"
+            ]
+          },
+          "then": {
+            "required": [
+              "event"
+            ]
+          }
         }
       ]
     },
@@ -1169,6 +1221,17 @@
                 }
               ],
               "description": "Key-value annotations for the transition"
+            },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/event"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional transition-level event definition. When present, this shared transition can also be triggered by an external event (action=transition). Required when triggerType is Event (3)."
             }
           }
         },
@@ -1260,6 +1323,23 @@
                 "type": "null"
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "triggerType": {
+                "const": 3
+              }
+            },
+            "required": [
+              "triggerType"
+            ]
+          },
+          "then": {
+            "required": [
+              "event"
+            ]
           }
         }
       ]

--- a/vocabularies/data-vocab.json
+++ b/vocabularies/data-vocab.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://unpkg.com/@burgan-tech/vnext-schema@__SCHEMA_VERSION__/vocabularies/data-vocab.json",
+  "x-stableId": "https://unpkg.com/@burgan-tech/vnext-schema/vocabularies/data-vocab.json",
+  "title": "vNext Data Context Vocabulary",
+  "description": "Vocabulary for schema-driven context-store binding. Provides reusable definitions for the x-context-source and x-context-target annotations that let a generic client wire a flow's inputs from, and persist its reusable outputs to, the client context-store purely from backend schemas. Backwards compatible: standard JSON Schema validators ignore these unknown x-* keywords, so a schema without them behaves exactly as today.",
+  "definitions": {
+    "contextSlot": {
+      "type": "object",
+      "description": "A context-store data slot. Usable as an x-context-source value (read) and as an x-context-target destination (write). The key template may interpolate {instance} (instance id) and {subject} (active subject); omit {instance} for cross-flow singletons that should live at a stable key.",
+      "required": [
+        "context"
+      ],
+      "properties": {
+        "context": {
+          "type": "object",
+          "required": [
+            "boundary",
+            "key"
+          ],
+          "properties": {
+            "boundary": {
+              "type": "string",
+              "enum": [
+                "device",
+                "user",
+                "subject"
+              ],
+              "description": "Context-store boundary the slot lives in."
+            },
+            "key": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Context-store key template. May interpolate {instance} and {subject}. Available template vars: {instance} (instance id), {subject} (active subject)."
+            },
+            "storage": {
+              "type": "string",
+              "enum": [
+                "memory",
+                "local",
+                "secure"
+              ],
+              "description": "Optional storage tier for the slot."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "identityRef": {
+      "type": "object",
+      "description": "A reference to a context-store identity (source only). Resolves to activeSubject (JWT sub) or activeUser.",
+      "required": [
+        "identity"
+      ],
+      "properties": {
+        "identity": {
+          "type": "string",
+          "enum": [
+            "subject",
+            "user"
+          ],
+          "description": "The context-store identity: 'subject' (active subject / JWT sub, e.g. the logged-in userId) or 'user' (active user)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "constLiteral": {
+      "type": "object",
+      "description": "A literal value baked into the schema (source only). Injected verbatim without prompting the user.",
+      "required": [
+        "const"
+      ],
+      "properties": {
+        "const": {
+          "description": "Any literal JSON value injected verbatim as the resolved input value."
+        }
+      },
+      "additionalProperties": false
+    },
+    "x-context-source": {
+      "description": "Annotation on a property of a transition-input schema. Marks the property as client-resolved rather than user input (the client does not render a form field for it). Resolved from one of: a literal (const), a context-store slot (context), or the context-store identity (identity).",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/constLiteral"
+        },
+        {
+          "$ref": "#/definitions/contextSlot"
+        },
+        {
+          "$ref": "#/definitions/identityRef"
+        }
+      ]
+    },
+    "x-context-target": {
+      "type": "object",
+      "description": "Annotation on a workflow master schema. Maps instance-data field paths (dot-notation; the target key may interpolate {instance}) to context-store slots. The client applies it on every instance read (start result, after each transition), so values that appear only after a transition propagate to the context-store and become available to later flows via x-context-source. Write destinations are context-store slots only (const and identity are source-only).",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/contextSlot"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What & why

Syncs the `@burgan-tech/vnext-schema` JSON schemas with new capabilities added to the vNext runtime (`burgan-tech/vnext`), so component authors get validation and editor autocomplete for them. All changes are schema-only and backwards compatible (purely additive).

## Changes

### 1. Task types 18 & 19 — `schemas/task-definition.schema.json`
- **Type 18 – Cache Aside Task** (`CacheAsideTask`): read-through cache pattern. `config` with `key`, `storeName`, `ttlInSeconds`, `consistency`, required `sourceTask` reference, optional `sourceMapping`/`keyExpression`, `bypassOnCacheError` (default true), `forceRefresh`.
- **Type 19 – Get Instance Task** (`GetInstanceTask`): full instance projection. `config` with required `domain`+`flow`, optional `key`/`instanceId`/`extensions`/`useDapr`/`headers`/`timeoutSeconds`/`validateSsl`/`acceptedStatusCodes`.
- Extends the `type` enum and positional `enumDescriptions`, plus two new `if/then` discriminator blocks (same pattern as the type-17 StateStore addition).

### 2. Event-workflow — `schemas/workflow-definition.schema.json`
- New reusable `#/definitions/event` = `{ mapping: scriptCode }` (mapping required).
- Workflow-level `attributes.event` (optional → external event can `start` an instance).
- `event` property added to **`transition`** and **`sharedTransition`**, each with a conditional enforcing: **`triggerType == 3` (Event) → `event` required**. Scope intentionally limited to these two (not cancel/exit/updateData/start).

### 3. Function read-through cache — `schemas/function-definition.schema.json`
- New `cache` object on `attributes` (`FunctionCache`): `keyExpression`, `key`, `storeName`, `ttlInSeconds`, `consistency`, `bypassOnCacheError` (default true), `generationKeyExpression`, `generationKey`.
- New `scriptExpression` definition for the dynamicExpresso key expressions — deliberately permissive on `location` (the existing `taskMapping` def restricts `location` to a `.csx` path, which would reject `location: "dynamicExpresso"`).

### 4. `vocabularies/data-vocab.json` (new)
- Reusable binding-location vocabulary for the "schema-driven context-store binding" proposal: `x-context-source` (const / context / identity) and `x-context-target` (field-path → context slot), plus helper defs `contextSlot`/`identityRef`/`constLiteral`. Follows the `view-vocab.json` convention; standalone fragment (not `$ref`'d by schemas, not exported from `index.js`).

## Verification

- `npm run validate` — all schemas (incl. new vocab) meta-validate as valid JSON Schema. ✅
- `npm run lint` — clean. ✅
- Scratch AJV instance-doc spot-checks run locally for each feature (valid + malformed cases): task 18/19 discriminators, event mandatory-vs-optional rule on transition/sharedTransition, function `cache` shapes, and the `data-vocab` `x-context-*` examples from the source proposal — all passed. (The repo's committed test suite only meta-validates schemas, so these were local spot-checks, not committed tests.)

## Reviewer notes

- Enum/`enumDescriptions` arrays in the task schema are positional — both were extended in lockstep.
- The transition `event`-required rule keys on integer `triggerType: 3` (there is no string/`"event"` value in this schema).
- No changes to `index.js` / `index.d.ts` / README needed (those track the 9 schemas only; vocabularies and per-task-type entries aren't enumerated there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update vNext JSON schemas to support new cache-related tasks, event-driven workflows, and function-level caching, and add a reusable data vocabulary fragment.

New Features:
- Add CacheAsideTask (type 18) and GetInstanceTask (type 19) definitions to the task schema, including discriminator rules and configuration fields.
- Introduce event workflow support with reusable event definitions and event-triggered transitions in the workflow schema.
- Add function-level cache configuration to the function schema, including key expressions and cache behavior options.
- Create a new data-vocab JSON vocabulary defining reusable context binding annotations for future schema-driven context-store bindings.

Enhancements:
- Relax script expression location constraints via a new scriptExpression definition to support dynamicExpresso-based expressions in function and task schemas.

Tests:
- Validate updated schemas and new vocabulary with the existing meta-validation and local AJV spot checks (not committed).