### PR TITLE
feat(schema): transition resourceLock, workflow config, DaprConversation task & function cache headers

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -321,6 +321,20 @@
                         "generationKey": {
                             "type": "string",
                             "description": "Optional static state key holding the cache generation stamp (used when generationKeyExpression is absent)."
+                        },
+                        "varyByHeaders": {
+                            "type": "array",
+                            "description": "Optional exact request-header names that vary the cached result.",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "varyByHeaderPrefixes": {
+                            "type": "array",
+                            "description": "Optional request-header name prefixes that vary the cached result.",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "additionalProperties": false

--- a/schemas/task-definition.schema.json
+++ b/schemas/task-definition.schema.json
@@ -85,7 +85,8 @@
                         "16",
                         "17",
                         "18",
-                        "19"
+                        "19",
+                        "20"
                     ],
                     "enumDescriptions": [
                         "Dapr HTTP Endpoint",
@@ -106,7 +107,8 @@
                         "SOAP Task",
                         "State Store Task",
                         "Cache Aside Task",
-                        "Get Instance Task"
+                        "Get Instance Task",
+                        "Dapr Conversation Task"
                     ]
                 }
             },
@@ -1484,6 +1486,73 @@
                                 "required": [
                                     "domain",
                                     "flow"
+                                ],
+                                "additionalProperties": false
+                            }
+                        },
+                        "required": [
+                            "type",
+                            "config"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "20"
+                            }
+                        }
+                    },
+                    "then": {
+                        "title": "Dapr Conversation Task",
+                        "properties": {
+                            "type": {
+                                "const": "20"
+                            },
+                            "config": {
+                                "type": "object",
+                                "description": "Dapr Conversation Task configuration - Invokes an LLM/AI provider through the Dapr Conversation building block.",
+                                "properties": {
+                                    "componentName": {
+                                        "type": "string",
+                                        "description": "Dapr conversation component name (the configured LLM provider), e.g. openai",
+                                        "minLength": 1
+                                    },
+                                    "inputs": {
+                                        "type": "array",
+                                        "description": "Conversation inputs as an array of role/content messages"
+                                    },
+                                    "parameters": {
+                                        "type": "object",
+                                        "description": "Provider-specific string parameters (e.g. model, maxTokens) forwarded to the component"
+                                    },
+                                    "metadata": {
+                                        "type": "object",
+                                        "description": "Dapr component metadata forwarded with the request"
+                                    },
+                                    "contextId": {
+                                        "type": "string",
+                                        "description": "Optional context identifier used to continue a stateful conversation"
+                                    },
+                                    "temperature": {
+                                        "type": "number",
+                                        "description": "Optional sampling temperature"
+                                    },
+                                    "scrubPII": {
+                                        "type": "boolean",
+                                        "description": "When true, requests the provider scrub PII from prompts and responses"
+                                    },
+                                    "timeoutSeconds": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "default": 30,
+                                        "description": "Timeout in seconds"
+                                    }
+                                },
+                                "required": [
+                                    "componentName"
                                 ],
                                 "additionalProperties": false
                             }

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -233,11 +233,96 @@
             }
           ],
           "description": "Optional workflow-level event definition. When present, an external event may start a new instance of this workflow (action=start). Independent of any transition-level event."
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/workflowConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional flow-level configuration container (currently function cache tuning). Null means host defaults apply."
         }
       }
     }
   },
   "definitions": {
+    "resourceLockDefinition": {
+      "type": "object",
+      "description": "Defines a distributed resource-lock operation to be executed during a transition. The keyExpression is compiled as an ITransitionMapping and evaluated at runtime to produce the lock key.",
+      "required": [
+        "keyExpression",
+        "action"
+      ],
+      "properties": {
+        "keyExpression": {
+          "$ref": "#/definitions/scriptCode",
+          "description": "Script compiled as ITransitionMapping whose handler returns the lock key string."
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "Acquire",
+            "Release",
+            "Extend"
+          ],
+          "enumDescriptions": [
+            "Acquires a distributed lock on the resource. Fails the transition if the resource is already locked by another owner.",
+            "Releases a previously acquired distributed lock on the resource.",
+            "Extends the TTL of an existing lock held by the same owner."
+          ],
+          "description": "The lock operation to perform."
+        },
+        "ttlSeconds": {
+          "type": "integer",
+          "default": 300,
+          "description": "Time-to-live in seconds for Acquire and Extend operations. Acts as a safety net so abandoned locks expire automatically."
+        },
+        "onConflict": {
+          "type": "string",
+          "enum": [
+            "Abort"
+          ],
+          "enumDescriptions": [
+            "Abort the transition immediately when the lock cannot be acquired."
+          ],
+          "default": "Abort",
+          "description": "Policy applied when the lock cannot be acquired (e.g., resource already locked)."
+        }
+      },
+      "additionalProperties": false
+    },
+    "workflowConfig": {
+      "type": "object",
+      "description": "Flow-level configuration container. Consolidates author-controlled, workflow-scoped settings under a single config object. Null means host defaults apply.",
+      "properties": {
+        "functionCache": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/functionCacheDefinition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional author-controlled cache tuning for the built-in instance functions (data, view, schema, ...). Null means host defaults apply."
+        }
+      },
+      "additionalProperties": false
+    },
+    "functionCacheDefinition": {
+      "type": "object",
+      "description": "Workflow-author-controlled cache tuning for the built-in instance functions (data, view, schema, ...). A single TTL covers all of them.",
+      "properties": {
+        "ttlSeconds": {
+          "type": "integer",
+          "description": "Cache TTL in seconds for this workflow's built-in function responses. Null or non-positive falls back to the host default (InstanceFunctionCache:DefaultTtlSeconds)."
+        }
+      },
+      "additionalProperties": false
+    },
     "roleGrant": {
       "type": "object",
       "required": [
@@ -909,6 +994,17 @@
                 }
               ],
               "description": "Optional transition-level event definition. When present, this transition can also be triggered by an external event (action=transition). Required when triggerType is Event (3)."
+            },
+            "resourceLock": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/resourceLockDefinition"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional distributed resource-lock operation executed during this transition. Valid only for start, state-level, and shared transitions."
             }
           }
         },
@@ -1232,6 +1328,17 @@
                 }
               ],
               "description": "Optional transition-level event definition. When present, this shared transition can also be triggered by an external event (action=transition). Required when triggerType is Event (3)."
+            },
+            "resourceLock": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/resourceLockDefinition"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional distributed resource-lock operation executed during this transition. Valid only for start, state-level, and shared transitions."
             }
           }
         },
@@ -1414,6 +1521,17 @@
               "type": "null"
             }
           ]
+        },
+        "resourceLock": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/resourceLockDefinition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional distributed resource-lock operation executed during this transition. Valid only for start, state-level, and shared transitions."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## What

Extends `workflow-definition.schema.json` (and the function cache/task schemas) to describe several new author-controlled features that already exist in the vNext runtime (C#) domain. The three commits on this branch:

### 1. Transition `resourceLock` (this session)
New `resourceLockDefinition` describing a distributed-lock operation evaluated during a transition:
- `keyExpression` — ScriptCode (`$ref` to existing `scriptCode`), **required**
- `action` — enum `Acquire` / `Release` / `Extend`, **required**
- `ttlSeconds` — integer, default `300`
- `onConflict` — enum `Abort`, default `Abort`

Wired into **start, state-level, and shared** transitions only. `cancel` / `exit` / `updateData` intentionally omit it, so their existing `additionalProperties: false` **rejects** the field automatically — no extra conditionals needed to enforce scope. Mirrors `Transition.ResourceLock` / `ResourceLockDefinition`.

### 2. Workflow `config` (this session)
New optional `config` object under `attributes` (alongside `cancel`/`exit`/`event`):
- `config.functionCache.ttlSeconds` (integer) via `workflowConfig` → `functionCacheDefinition`

Field name is `ttlSeconds` (deliberately distinct from the function-level cache's `ttlInSeconds`) to match the C# `WorkflowConfig` / `FunctionCacheDefinition` JSON shape.

### 3. Prior commits on the branch
- `DaprConversation` task type (20)
- `varyByHeaders` / `varyByHeaderPrefixes` on the function-level cache

## Why
Keep `@burgan-tech/vnext-schema` in sync with the runtime so component JSON validates against the runtime's deserialization shape.

## Notes for reviewers
- All additions are inline `definitions` referenced via `$ref` — no new schema files, no `index.js` / `index.d.ts` changes.
- Scope enforcement for `resourceLock` relies on `additionalProperties: false` in the strict transition definitions.

## Verification
- `npm test` (AJV schema validation) — all schemas valid ✅
- `npm run lint` — clean ✅
- Ad-hoc AJV functional check (7/7): resourceLock accepted on state/start/shared, rejected on cancel; `resourceLock` missing `action` rejected; `config.functionCache.ttlSeconds` accepted; unknown key under `functionCache` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend workflow, function, and task schemas to align with new runtime capabilities for resource locks, workflow configuration, DaprConversation tasks, and function cache headers.

New Features:
- Describe resource lock operations in start, state-level, and shared workflow transitions.
- Add workflow-level configuration for function cache TTL in the workflow schema.
- Introduce a DaprConversation task type in the task schema.
- Support header-based variation (by specific headers and header prefixes) in function-level cache configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for header-based cache variation using exact header names or prefixes.
  * Added the Dapr Conversation Task type with conversation settings such as inputs, metadata, context, temperature, PII scrubbing, and timeouts.
  * Added workflow configuration for function cache tuning.
  * Added resource lock settings for transitions, including lock actions, expiration, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->