### PR TITLE
feat(schema): view SDI/MDI display modes and function contract declaration

### DIFF
--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -280,6 +280,51 @@
                     "type": "boolean",
                     "description": "When true, the function returns the task response as-is without wrapping/transformation."
                 },
+                "verbs": {
+                    "type": "array",
+                    "description": "HTTP verbs this function supports. When omitted or empty, no verb restriction is applied (backward compatible).",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "GET",
+                            "POST",
+                            "PATCH",
+                            "DELETE"
+                        ],
+                        "enumDescriptions": [
+                            "Read without a request body",
+                            "Create or invoke with a request body",
+                            "Partial update with a request body",
+                            "Delete"
+                        ]
+                    }
+                },
+                "inputSchema": {
+                    "description": "Reference to the sys-schemas component describing the request body. When set, the runtime validates the request body against it.",
+                    "allOf": [
+                        { "$ref": "#/definitions/schemaComponentRef" }
+                    ]
+                },
+                "outputSchema": {
+                    "description": "Reference to the sys-schemas component describing the response body. Declarative only - not enforced at runtime.",
+                    "allOf": [
+                        { "$ref": "#/definitions/schemaComponentRef" }
+                    ]
+                },
+                "inputView": {
+                    "description": "Reference to the sys-views component the client renders to collect this function's input.",
+                    "allOf": [
+                        { "$ref": "#/definitions/viewComponentRef" }
+                    ]
+                },
+                "outputView": {
+                    "description": "Reference to the sys-views component the client renders to present this function's output.",
+                    "allOf": [
+                        { "$ref": "#/definitions/viewComponentRef" }
+                    ]
+                },
                 "cache": {
                     "type": "object",
                     "description": "Optional read-through cache configuration. When set, the function's response is served from the cache on a hit (tasks skipped) and written to the cache on a miss. Only side-effect-free (read) functions should enable this.",
@@ -345,6 +390,92 @@
     },
     "additionalProperties": false,
     "definitions": {
+        "componentRef": {
+            "description": "Reference to another component - either an explicit reference or a file $ref.",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "description": "Explicit component reference",
+                    "required": [
+                        "key",
+                        "domain",
+                        "flow",
+                        "version"
+                    ],
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "description": "Component key"
+                        },
+                        "domain": {
+                            "type": "string",
+                            "description": "Component domain"
+                        },
+                        "flow": {
+                            "type": "string",
+                            "description": "Component flow (e.g. sys-schemas, sys-views)"
+                        },
+                        "version": {
+                            "type": "string",
+                            "description": "Component version"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "description": "Component reference using ref",
+                    "required": [
+                        "ref"
+                    ],
+                    "properties": {
+                        "ref": {
+                            "type": "string",
+                            "description": "Reference to component file"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "schemaComponentRef": {
+            "description": "Reference to a sys-schemas component.",
+            "allOf": [
+                { "$ref": "#/definitions/componentRef" },
+                {
+                    "if": {
+                        "type": "object",
+                        "required": ["flow"]
+                    },
+                    "then": {
+                        "properties": {
+                            "flow": {
+                                "const": "sys-schemas"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "viewComponentRef": {
+            "description": "Reference to a sys-views component.",
+            "allOf": [
+                { "$ref": "#/definitions/componentRef" },
+                {
+                    "if": {
+                        "type": "object",
+                        "required": ["flow"]
+                    },
+                    "then": {
+                        "properties": {
+                            "flow": {
+                                "const": "sys-views"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "taskMapping": {
             "type": "object",
             "description": "Mapping code definition",

--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -124,32 +124,13 @@
                     }
                 },
                 "display": {
-                    "type": "string",
-                    "description": "View display mode",
+                    "description": "View display mode. String form declares the SDI (single-document) display and is the backward-compatible shape. Object form declares the display per client mode.",
                     "oneOf": [
                         {
-                            "const": "full-page",
-                            "description": "Full page display"
+                            "$ref": "#/definitions/sdiDisplay"
                         },
                         {
-                            "const": "popup",
-                            "description": "Popup/modal display"
-                        },
-                        {
-                            "const": "bottom-sheet",
-                            "description": "Bottom sheet display"
-                        },
-                        {
-                            "const": "top-sheet",
-                            "description": "Top sheet display"
-                        },
-                        {
-                            "const": "drawer",
-                            "description": "Drawer/side menu display"
-                        },
-                        {
-                            "const": "inline",
-                            "description": "Inline display within page"
+                            "$ref": "#/definitions/displayModes"
                         }
                     ]
                 },
@@ -209,5 +190,84 @@
             "additionalProperties": false
         }
     },
-    "additionalProperties": false
+    "additionalProperties": false,
+    "definitions": {
+        "sdiDisplay": {
+            "type": "string",
+            "description": "Display mode for SDI (single-document interface) clients.",
+            "oneOf": [
+                {
+                    "const": "full-page",
+                    "description": "Full page display"
+                },
+                {
+                    "const": "popup",
+                    "description": "Popup/modal display"
+                },
+                {
+                    "const": "bottom-sheet",
+                    "description": "Bottom sheet display"
+                },
+                {
+                    "const": "top-sheet",
+                    "description": "Top sheet display"
+                },
+                {
+                    "const": "drawer",
+                    "description": "Drawer/side menu display"
+                },
+                {
+                    "const": "inline",
+                    "description": "Inline display within page"
+                }
+            ]
+        },
+        "mdiDisplay": {
+            "type": "string",
+            "description": "Display mode for MDI (multi-document interface) clients.",
+            "oneOf": [
+                {
+                    "const": "tab",
+                    "description": "Opens as a tab in the document area"
+                },
+                {
+                    "const": "window",
+                    "description": "Opens as a floating/detached window"
+                },
+                {
+                    "const": "split",
+                    "description": "Opens in a split pane next to the active document"
+                },
+                {
+                    "const": "inline",
+                    "description": "Inline display within the active document"
+                }
+            ]
+        },
+        "displayModes": {
+            "type": "object",
+            "description": "Per-mode display declaration. At least one of sdi or mdi must be present.",
+            "properties": {
+                "sdi": {
+                    "$ref": "#/definitions/sdiDisplay"
+                },
+                "mdi": {
+                    "$ref": "#/definitions/mdiDisplay"
+                }
+            },
+            "anyOf": [
+                {
+                    "required": [
+                        "sdi"
+                    ]
+                },
+                {
+                    "required": [
+                        "mdi"
+                    ]
+                }
+            ],
+            "additionalProperties": false
+        }
+    }
 }


### PR DESCRIPTION
## Why

Two gaps in what a component can tell a client:

1. **View** exposed a single `display` string (`full-page`, `popup`, `drawer`, …). Those values only describe a **single-document (SDI)** presentation. Client renderers also support **MDI**, where several documents are open side by side, and a view had no way to say whether it lands as a tab, a floating window, or a split pane.
2. **Function** declared no contract at all — no request/response schema, no input/output view, and no indication of which HTTP verbs it accepts. A client could not answer "what do I send, what do I get back, and how do I call it?" from the definition.

## What changed

### `view-definition.schema.json`

`attributes.display` now accepts **either** shape:

```jsonc
"display": "popup"                          // legacy — means sdi: "popup"
"display": { "sdi": "popup", "mdi": "tab" } // both modes
"display": { "mdi": "window" }              // MDI only
```

- The six existing SDI values moved verbatim into `definitions.sdiDisplay`.
- `definitions.mdiDisplay` is new: `tab`, `window`, `split`, `inline`.
- `definitions.displayModes` requires at least one of `sdi` / `mdi`, `additionalProperties: false`.

### `function-definition.schema.json`

Five new optional `attributes` fields:

| Field | Purpose |
| --- | --- |
| `verbs[]` | Supported HTTP verbs: `GET`, `POST`, `PATCH`, `DELETE`. Absent/empty = no restriction. |
| `inputSchema` | `sys-schemas` ref describing the request body. |
| `outputSchema` | `sys-schemas` ref describing the response body. |
| `inputView` | `sys-views` ref the client renders to collect input. |
| `outputView` | `sys-views` ref the client renders to present output. |

New `definitions.componentRef` mirrors the workflow schema's reference shape (explicit `key`/`domain`/`flow`/`version`, or a file `ref`). `schemaComponentRef` / `viewComponentRef` wrap it to pin the expected flow, so an `inputSchema` cannot point at `sys-views` and an `inputView` cannot point at `sys-schemas`.

## Backward compatibility

**No breaking changes.** Every existing view and function component validates unchanged — the legacy `display` string is still a first-class form, and all five function fields are optional.

## Note for reviewers: no QUERY verb

An earlier revision included `QUERY` (a safe, idempotent read carrying a request body) in the verb enum. It was **deliberately removed**. .NET 10 supports the method at the HTTP layer and routing it is straightforward, but the surrounding ecosystem — Swagger/OpenAPI generation, gateways, WAFs, client SDKs — does not handle an unrecognised method, so enabling it breaks tooling before it buys anything. Body-carrying reads should be modelled as `POST` for now. Worth revisiting once that support lands.

## Verification

- `npm test` (AJV compile of every schema) — passes.
- `npm run lint` — clean.
- 27 ad-hoc document cases run against the compiled schemas, all passing:
  - legacy string `display`, object with both modes, MDI-only, SDI-only, omitted
  - rejects: unknown display value, an SDI value in the `mdi` slot, empty object, extra keys
  - accepts all four verbs; rejects `PUT`, lowercase verbs, duplicates, empty array, and `QUERY`
  - accepts all four refs in explicit and file-`ref` form; rejects wrong-flow refs and refs missing `version`

The consuming runtime changes live in `burgan-tech/vnext` and will be raised separately; this PR is the contract only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend view and function component schemas to describe display modes and function call contracts without breaking existing definitions.

New Features:
- Allow views to declare both SDI and MDI display modes via an expanded display attribute shape.
- Introduce optional function attributes for supported HTTP verbs, input/output schemas, and input/output views.
- Add component reference definitions for schemas and views to constrain function input/output targets to the correct flows.

Enhancements:
- Keep legacy view display strings fully supported while adding structured display mode definitions for SDI and MDI.
- Align function component reference shapes with workflow schema references to ensure consistent cross-component linking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Functions can now declare supported HTTP verbs and reference request/response schemas and input/output views.
  * Added support for reusable schema and view component references.
  * View display settings can now support SDI, MDI, or both display modes through structured configuration.

* **Compatibility**
  * Existing SDI display string configurations remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->