### PR TITLE
feat(schema): allow availableIn on cancel/exit/updateData transitions

### DIFF
--- a/docs/components/workflow-definition.md
+++ b/docs/components/workflow-definition.md
@@ -237,6 +237,7 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| availableIn | string[] | No | No | States where cancel is available; empty/absent = every state (since 0.0.79) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
@@ -261,12 +262,18 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| availableIn | string[] | No | No | States where exit is available; empty/absent = every state (since 0.0.79) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
 | _comment | string | No | No | - |
 
 **Not available:** rule, timer, triggerKind
+
+**Runtime behavior (since 0.0.79):** `exit` is listed in the State function's `availableTransitions`
+(with `kind: "exit"`, carrying the **configured** `key` — not the `exit` alias), and its `roles` are
+evaluated when that list is filtered per caller and by `/functions/authorize`. Before 0.0.79 `roles`
+was accepted by the schema but never evaluated.
 
 ---
 
@@ -285,6 +292,7 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
+| availableIn | string[] | No | No | States where updateData is available; empty/absent = every state (since 0.0.79) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
@@ -293,6 +301,13 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 **Unique constraint:** `target` is always `$self` -- update data never changes state.
 
 **Not available:** rule, timer, triggerKind
+
+**Runtime behavior (since 0.0.79):** `updateData` is listed in the State function's
+`availableTransitions` (with `kind: "updateData"` — note the field name, not the `update-parent-data`
+request alias — carrying the **configured** `key`), and its `roles` are evaluated when that list is
+filtered per caller and by `/functions/authorize`. While an instance sits in a `SubFlow` state the
+parent's `updateData` is merged into the subflow's list; that is its primary surface, since it only
+does work in that situation. Before 0.0.79 `roles` was accepted by the schema but never evaluated.
 
 ---
 

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -1612,6 +1612,13 @@
           ],
           "description": "Optional mapping definition for cancel transition input data transformation"
         },
+        "availableIn": {
+          "type": "array",
+          "description": "States where this cancel transition is available. Empty or absent means every state (same semantics as shared transitions).",
+          "items": {
+            "type": "string"
+          }
+        },
         "roles": {
           "type": "array",
           "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
@@ -1709,6 +1716,13 @@
           ],
           "description": "Optional mapping definition for exit transition input data transformation"
         },
+        "availableIn": {
+          "type": "array",
+          "description": "States where this exit transition is available. Empty or absent means every state (same semantics as shared transitions).",
+          "items": {
+            "type": "string"
+          }
+        },
         "roles": {
           "type": "array",
           "description": "Transition roles for authorization. DENY overrides ALLOW; default DENY when no match.",
@@ -1805,6 +1819,13 @@
             }
           ],
           "description": "Optional mapping definition for update data transition input data transformation"
+        },
+        "availableIn": {
+          "type": "array",
+          "description": "States where this update data transition is available. Empty or absent means every state (same semantics as shared transitions).",
+          "items": {
+            "type": "string"
+          }
         },
         "roles": {
           "type": "array",


### PR DESCRIPTION
## What

Adds `availableIn` (array of state keys) to the `cancelTransition`, `exitTransition` and `updateDataTransition` definitions in `schemas/workflow-definition.schema.json`, mirroring `sharedTransition`'s existing shape.

## Why

This closes a **schema/runtime gap** rather than adding a capability.

The runtime has always honored `availableIn` on these three transitions — the availability gate in `Workflow.GetAvailableUserTransitionKeys` checks it exactly as it does for shared transitions — and `docs/components/workflow-definition.md`'s own Transition Type Comparison Matrix already listed `availableIn` as **Optional** for `cancelTransition`, `exitTransition` and `updateDataTransition`.

But none of the three definitions declared the field, and all three are `additionalProperties: false`. So authoring it was rejected at validation time and the runtime gate was unreachable. The docs, the schema, and the runtime disagreed; this makes them agree.

Empty or absent continues to mean "available in every state", identical to shared-transition semantics.

## Docs

`docs/components/workflow-definition.md`:
- `availableIn` added to the field table of all three transition types.
- Runtime-behavior notes added for `exit` and `updateData`, recording that they are now listed in the State function's `availableTransitions` and that their `roles` are enforced. `roles` has been accepted by the schema since 0.0.44 but was never evaluated — the runtime never put these keys into the list the role filter operates on, so it was dead configuration.

## Companion runtime change

This PR is schema-only. The runtime side lands separately in `burgan-tech/vnext`:
- `updateData` / `exit` appended to `availableTransitions` (configured key, not the well-known alias, because role filtering resolves via `FindTransitionInContext`).
- Parent's `cancel` / `updateData` / `exit` merged into a subflow's transition list.
- `kind` discriminator `updateData` (the JSON field name, **not** the `update-parent-data` request alias).
- `WorkflowValidator` routes `UpdateData` and `Exit` through the same single-transition validation as `Cancel`.

Merge order does not matter — the schema change is additive and optional, so neither side depends on the other to stay valid.

## Reviewer notes

- **Not a breaking change.** The field is optional, nothing was removed or tightened, and `additionalProperties: false` still rejects unknown siblings.
- `items` is `{ "type": "string" }` with no pattern, matching `sharedTransition.availableIn` exactly rather than applying the stricter `^[a-z0-9-]+$` state-key pattern used elsewhere. Deliberate — parity with the closest analog in the same file. Worth a second opinion if you'd rather tighten both together in a follow-up.
- Placed immediately before `roles` in each definition, mirroring `sharedTransition`'s property ordering.

## Verification

- `npm test` — all schema files valid.
- Ajv (draft 2019) against the real schema, on a workflow declaring `availableIn` on all three transitions plus a dynamic `roles` grant:
  - valid as authored;
  - `additionalProperties: false` still rejects an unknown sibling on `exitTransition`;
  - `availableIn` still rejects a bare string instead of an array.
- Runtime binding confirmed on the `vnext` side by a test that deserializes component JSON through the production serializer options and asserts `exit` with `availableIn: ["review"]` is offered in `review` but not `pending`, while `availableIn: []` means every state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align workflow-definition schema and docs with runtime behavior for cancel, exit, and updateData transitions by declaring the availableIn field and documenting its semantics.

Documentation:
- Document availableIn as an optional string[] field for cancel, exit, and updateData transitions, noting semantics for empty/absent values.
- Describe runtime behavior for exit and updateData transitions, including their presence in availableTransitions and enforcement of roles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional state-based availability controls for cancel, exit, and update-data transitions.
  * Transitions without specified states remain available in every state.
  * Documented runtime visibility and authorization behavior, including role filtering and update-data merging across workflow levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->