### PR TITLE
feat(schema): accept rule-based view/schema contracts on functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node test/validate-schemas.js",
+    "test": "node test/validate-schemas.js && node test/validate-function-documents.js",
     "test:coverage": "nyc npm test",
     "lint": "eslint . --fix",
     "validate": "npm run test",

--- a/schemas/function-definition.schema.json
+++ b/schemas/function-definition.schema.json
@@ -63,14 +63,26 @@
                 "scope"
             ],
             "anyOf": [
-                { "required": ["task"] },
-                { "required": ["onExecutionTasks"] }
+                {
+                    "required": [
+                        "task"
+                    ]
+                },
+                {
+                    "required": [
+                        "onExecutionTasks"
+                    ]
+                }
             ],
             "if": {
-                "required": ["onExecutionTasks"]
+                "required": [
+                    "onExecutionTasks"
+                ]
             },
             "then": {
-                "required": ["output"]
+                "required": [
+                    "output"
+                ]
             },
             "properties": {
                 "scope": {
@@ -240,7 +252,9 @@
                 "output": {
                     "description": "Output mapping for multi-task execution result. Required when onExecutionTasks is defined.",
                     "allOf": [
-                        { "$ref": "#/definitions/taskMapping" }
+                        {
+                            "$ref": "#/definitions/taskMapping"
+                        }
                     ]
                 },
                 "labels": {
@@ -302,27 +316,35 @@
                     }
                 },
                 "inputSchema": {
-                    "description": "Reference to the sys-schemas component describing the request body. When set, the runtime validates the request body against it.",
+                    "description": "The sys-schemas contract describing the request body. When set, the runtime validates the request body against the entry that wins rule evaluation.",
                     "allOf": [
-                        { "$ref": "#/definitions/schemaComponentRef" }
+                        {
+                            "$ref": "#/definitions/schemaSlot"
+                        }
                     ]
                 },
                 "outputSchema": {
-                    "description": "Reference to the sys-schemas component describing the response body. Declarative only - not enforced at runtime.",
+                    "description": "The sys-schemas contract describing the response body. Declarative only - not enforced at runtime.",
                     "allOf": [
-                        { "$ref": "#/definitions/schemaComponentRef" }
+                        {
+                            "$ref": "#/definitions/schemaSlot"
+                        }
                     ]
                 },
                 "inputView": {
-                    "description": "Reference to the sys-views component the client renders to collect this function's input.",
+                    "description": "The sys-views contract the client renders to collect this function's input.",
                     "allOf": [
-                        { "$ref": "#/definitions/viewComponentRef" }
+                        {
+                            "$ref": "#/definitions/viewSlot"
+                        }
                     ]
                 },
                 "outputView": {
-                    "description": "Reference to the sys-views component the client renders to present this function's output.",
+                    "description": "The sys-views contract the client renders to present this function's output.",
                     "allOf": [
-                        { "$ref": "#/definitions/viewComponentRef" }
+                        {
+                            "$ref": "#/definitions/viewSlot"
+                        }
                     ]
                 },
                 "cache": {
@@ -332,7 +354,9 @@
                         "keyExpression": {
                             "description": "Optional Dynamic Expresso expression (a ScriptCode with location 'dynamicExpresso') that computes the cache key from the request/script context and returns a string. Takes precedence over 'key'.",
                             "allOf": [
-                                { "$ref": "#/definitions/scriptExpression" }
+                                {
+                                    "$ref": "#/definitions/scriptExpression"
+                                }
                             ]
                         },
                         "key": {
@@ -349,7 +373,10 @@
                         },
                         "consistency": {
                             "type": "string",
-                            "enum": ["Eventual", "Strong"],
+                            "enum": [
+                                "Eventual",
+                                "Strong"
+                            ],
                             "description": "Optional consistency mode: Eventual (default) or Strong."
                         },
                         "bypassOnCacheError": {
@@ -360,7 +387,9 @@
                         "generationKeyExpression": {
                             "description": "Optional Dynamic Expresso expression resolving to the state key that holds this config's cache generation stamp. When configured, the runtime folds the stamp into the cache key for generation-namespace invalidation. Takes precedence over generationKey.",
                             "allOf": [
-                                { "$ref": "#/definitions/scriptExpression" }
+                                {
+                                    "$ref": "#/definitions/scriptExpression"
+                                }
                             ]
                         },
                         "generationKey": {
@@ -441,11 +470,15 @@
         "schemaComponentRef": {
             "description": "Reference to a sys-schemas component.",
             "allOf": [
-                { "$ref": "#/definitions/componentRef" },
+                {
+                    "$ref": "#/definitions/componentRef"
+                },
                 {
                     "if": {
                         "type": "object",
-                        "required": ["flow"]
+                        "required": [
+                            "flow"
+                        ]
                     },
                     "then": {
                         "properties": {
@@ -460,11 +493,15 @@
         "viewComponentRef": {
             "description": "Reference to a sys-views component.",
             "allOf": [
-                { "$ref": "#/definitions/componentRef" },
+                {
+                    "$ref": "#/definitions/componentRef"
+                },
                 {
                     "if": {
                         "type": "object",
-                        "required": ["flow"]
+                        "required": [
+                            "flow"
+                        ]
                     },
                     "then": {
                         "properties": {
@@ -482,7 +519,10 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["G", "L"],
+                    "enum": [
+                        "G",
+                        "L"
+                    ],
                     "enumDescriptions": [
                         "Global",
                         "Local"
@@ -510,7 +550,11 @@
                 "encoding": {
                     "type": "string",
                     "description": "Code encoding format",
-                    "enum": ["B64", "NAT", "REF"],
+                    "enum": [
+                        "B64",
+                        "NAT",
+                        "REF"
+                    ],
                     "default": "B64"
                 },
                 "scripts": {
@@ -531,7 +575,9 @@
                         "required": []
                     },
                     "else": {
-                        "required": ["code"]
+                        "required": [
+                            "code"
+                        ]
                     }
                 },
                 {
@@ -541,10 +587,14 @@
                                 "const": "REF"
                             }
                         },
-                        "required": ["encoding"]
+                        "required": [
+                            "encoding"
+                        ]
                     },
                     "then": {
-                        "required": ["code"],
+                        "required": [
+                            "code"
+                        ],
                         "properties": {
                             "code": {
                                 "$ref": "#/definitions/mappingRef"
@@ -614,7 +664,10 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "enum": ["G", "L"],
+                    "enum": [
+                        "G",
+                        "L"
+                    ],
                     "enumDescriptions": [
                         "Global",
                         "Local"
@@ -634,7 +687,11 @@
                 "encoding": {
                     "type": "string",
                     "description": "Code encoding format",
-                    "enum": ["B64", "NAT", "REF"],
+                    "enum": [
+                        "B64",
+                        "NAT",
+                        "REF"
+                    ],
                     "default": "B64"
                 },
                 "scripts": {
@@ -645,7 +702,10 @@
         },
         "roleGrant": {
             "type": "object",
-            "required": ["role", "grant"],
+            "required": [
+                "role",
+                "grant"
+            ],
             "properties": {
                 "role": {
                     "type": "string",
@@ -653,11 +713,183 @@
                 },
                 "grant": {
                     "type": "string",
-                    "enum": ["allow", "deny"],
+                    "enum": [
+                        "allow",
+                        "deny"
+                    ],
                     "description": "DENY always overrides ALLOW"
                 }
             },
             "additionalProperties": false
+        },
+        "scriptCode": {
+            "type": "object",
+            "description": "An inline C# script implementing IConditionMapping, evaluated to decide whether the entry it belongs to is selected.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "G",
+                        "L"
+                    ],
+                    "enumDescriptions": [
+                        "Global",
+                        "Local"
+                    ],
+                    "default": "L",
+                    "description": "Script type - Global or Local"
+                },
+                "code": {
+                    "description": "Script code content (string), or a sys-mappings reference when encoding is REF.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/mappingRef"
+                        }
+                    ]
+                },
+                "location": {
+                    "type": "string",
+                    "description": "Location of the script file"
+                },
+                "encoding": {
+                    "type": "string",
+                    "description": "Code encoding format",
+                    "enum": [
+                        "B64",
+                        "NAT",
+                        "REF"
+                    ],
+                    "default": "B64"
+                },
+                "scripts": {
+                    "$ref": "#/definitions/scripts"
+                }
+            },
+            "required": [
+                "code"
+            ],
+            "additionalProperties": false
+        },
+        "viewRuleEntry": {
+            "type": "object",
+            "description": "One entry of a rule-based view slot. Entries are evaluated in declaration order and the first match wins; an entry without a rule always matches, so it must be the last entry.",
+            "properties": {
+                "rule": {
+                    "description": "Selection rule. Omit on the final fallback entry.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/scriptCode"
+                        }
+                    ]
+                },
+                "view": {
+                    "description": "The sys-views component this entry selects.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/viewComponentRef"
+                        }
+                    ]
+                },
+                "loadData": {
+                    "type": "boolean",
+                    "description": "Whether the client should load instance data alongside this view."
+                }
+            },
+            "required": [
+                "view"
+            ],
+            "additionalProperties": false
+        },
+        "schemaRuleEntry": {
+            "type": "object",
+            "description": "One entry of a rule-based schema slot. Entries are evaluated in declaration order and the first match wins; an entry without a rule always matches, so it must be the last entry.",
+            "properties": {
+                "rule": {
+                    "description": "Selection rule. Omit on the final fallback entry.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/scriptCode"
+                        }
+                    ]
+                },
+                "schema": {
+                    "description": "The sys-schemas component this entry selects.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/schemaComponentRef"
+                        }
+                    ]
+                }
+            },
+            "required": [
+                "schema"
+            ],
+            "additionalProperties": false
+        },
+        "viewSlot": {
+            "description": "A view contract: either a single sys-views reference, or rule-based entries evaluated in order (first match wins, a trailing rule-less entry is the fallback).",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/viewComponentRef"
+                },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/viewRuleEntry"
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "views"
+                    ],
+                    "properties": {
+                        "views": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/definitions/viewRuleEntry"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "schemaSlot": {
+            "description": "A schema contract: either a single sys-schemas reference, or rule-based entries evaluated in order (first match wins, a trailing rule-less entry is the fallback).",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/schemaComponentRef"
+                },
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "$ref": "#/definitions/schemaRuleEntry"
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": [
+                        "schemas"
+                    ],
+                    "properties": {
+                        "schemas": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "$ref": "#/definitions/schemaRuleEntry"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
         }
     }
 }

--- a/test/validate-function-documents.js
+++ b/test/validate-function-documents.js
@@ -1,0 +1,154 @@
+/**
+ * Document-level tests for function-definition.schema.json.
+ *
+ * validate-schemas.js only checks that each schema is itself a valid JSON Schema. That cannot catch a
+ * contract slot that accepts the wrong shape, so this file validates real function documents against
+ * the schema - in particular the polymorphic contract slots (inputSchema / outputSchema / inputView /
+ * outputView), each of which accepts a single component reference, a rule-based entry array, or the
+ * wrapped array object.
+ */
+
+const path = require('path');
+const Ajv = require('ajv');
+
+const schema = require(path.join(__dirname, '../schemas/function-definition.schema.json'));
+
+const DOMAIN = 'test-domain';
+const VERSION = '1.0.0';
+
+const ref = (key, flow) => ({ key, domain: DOMAIN, flow, version: VERSION });
+const rule = () => ({ location: '', code: 'true', encoding: 'NAT' });
+
+/** A minimal, valid function document with the given attribute overrides merged in. */
+const doc = (attributes = {}) => ({
+  key: 'my-fn',
+  version: VERSION,
+  domain: DOMAIN,
+  flow: 'sys-functions',
+  flowVersion: VERSION,
+  tags: ['function'],
+  attributes: {
+    scope: 'D',
+    task: {
+      order: 1,
+      task: ref('my-task', 'sys-tasks'),
+      mapping: { location: './my-task.csx', code: 'cmV0dXJuIHt9Ow==', encoding: 'B64' }
+    },
+    ...attributes
+  }
+});
+
+const VIEW_SLOTS = ['inputView', 'outputView'];
+const SCHEMA_SLOTS = ['inputSchema', 'outputSchema'];
+
+const cases = [];
+
+const expectValid = (name, document) => cases.push({ name, document, valid: true });
+const expectInvalid = (name, document) => cases.push({ name, document, valid: false });
+
+expectValid('minimal function', doc());
+
+for (const slot of VIEW_SLOTS) {
+  expectValid(`${slot}: single reference`, doc({ [slot]: ref('v1', 'sys-views') }));
+
+  expectValid(`${slot}: rule entries with a trailing fallback`, doc({
+    [slot]: [
+      { rule: rule(), view: ref('v1', 'sys-views'), loadData: true },
+      { view: ref('v2', 'sys-views') }
+    ]
+  }));
+
+  expectValid(`${slot}: wrapped views array`, doc({
+    [slot]: { views: [{ view: ref('v1', 'sys-views') }] }
+  }));
+
+  expectInvalid(`${slot}: entry without a view`, doc({ [slot]: [{ rule: rule() }] }));
+
+  expectInvalid(`${slot}: reference to the wrong flow`, doc({ [slot]: ref('v1', 'sys-schemas') }));
+
+  // 'extensions' only applies to state/transition views; the runtime validator rejects it on a
+  // function, so the schema must not accept it either.
+  expectInvalid(`${slot}: entry declaring extensions`, doc({
+    [slot]: [{ view: ref('v1', 'sys-views'), extensions: ['e1'] }]
+  }));
+
+  expectInvalid(`${slot}: empty array`, doc({ [slot]: [] }));
+
+  expectInvalid(`${slot}: schema-style entry`, doc({
+    [slot]: [{ schema: ref('s1', 'sys-schemas') }]
+  }));
+}
+
+for (const slot of SCHEMA_SLOTS) {
+  expectValid(`${slot}: single reference`, doc({ [slot]: ref('s1', 'sys-schemas') }));
+
+  expectValid(`${slot}: rule entries with a trailing fallback`, doc({
+    [slot]: [
+      { rule: rule(), schema: ref('s1', 'sys-schemas') },
+      { schema: ref('s2', 'sys-schemas') }
+    ]
+  }));
+
+  expectValid(`${slot}: wrapped schemas array`, doc({
+    [slot]: { schemas: [{ schema: ref('s1', 'sys-schemas') }] }
+  }));
+
+  expectInvalid(`${slot}: entry without a schema`, doc({ [slot]: [{ rule: rule() }] }));
+
+  expectInvalid(`${slot}: reference to the wrong flow`, doc({ [slot]: ref('s1', 'sys-views') }));
+
+  // loadData is a view rendering hint; a payload contract has no use for it.
+  expectInvalid(`${slot}: entry declaring loadData`, doc({
+    [slot]: [{ schema: ref('s1', 'sys-schemas'), loadData: true }]
+  }));
+
+  expectInvalid(`${slot}: empty array`, doc({ [slot]: [] }));
+}
+
+expectValid('all four slots together, mixing shapes', doc({
+  verbs: ['POST'],
+  inputSchema: [
+    { rule: rule(), schema: ref('s1', 'sys-schemas') },
+    { schema: ref('s2', 'sys-schemas') }
+  ],
+  outputSchema: ref('s3', 'sys-schemas'),
+  inputView: { views: [{ rule: rule(), view: ref('v1', 'sys-views') }, { view: ref('v2', 'sys-views') }] },
+  outputView: ref('v3', 'sys-views')
+}));
+
+function run() {
+  console.log('🔍 Function document validation starting...\n');
+
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema);
+
+  let failures = 0;
+
+  for (const { name, document, valid } of cases) {
+    const actual = validate(document);
+
+    if (actual === valid) {
+      console.log(`✅ ${name}${valid ? '' : ' (correctly rejected)'}`);
+      continue;
+    }
+
+    failures++;
+    if (valid) {
+      console.log(`❌ ${name} - expected valid but was rejected:`);
+      (validate.errors || []).forEach(e => console.log(`   - ${e.instancePath}: ${e.message}`));
+    } else {
+      console.log(`❌ ${name} - expected rejection but was accepted`);
+    }
+  }
+
+  console.log('');
+  if (failures === 0) {
+    console.log(`🎉 All ${cases.length} function documents behaved as expected!`);
+    process.exit(0);
+  }
+
+  console.log(`💥 ${failures} of ${cases.length} function document cases failed.`);
+  process.exit(1);
+}
+
+run();


### PR DESCRIPTION
## What

The four function contract slots — `inputSchema`, `outputSchema`, `inputView`, `outputView` — each accept three interchangeable shapes instead of only a single component reference:

```jsonc
// 1. Single reference — unchanged, still the common case.
"inputView": { "key": "search-form", "domain": "core", "flow": "sys-views", "version": "1.0.0" }

// 2. Rule entries — declaration order, first match wins, trailing rule-less entry is the fallback.
"inputView": [
  { "rule": { "location": "./mobile.csx", "code": "...", "encoding": "B64" },
    "view": { "key": "search-form-mobile", "domain": "core", "flow": "sys-views", "version": "1.0.0" },
    "loadData": true },
  { "view": { "key": "search-form", "domain": "core", "flow": "sys-views", "version": "1.0.0" } }
]

// 3. Wrapped array — what the runtime serializes back.
"inputView": { "views": [ … ] }
```

Schema slots use `schema` instead of `view`, and `{ "schemas": [...] }` as the wrapper.

New `definitions`: `scriptCode`, `viewRuleEntry`, `schemaRuleEntry`, `viewSlot`, `schemaSlot`.

## Why

Those slots were added (#128) to make a function usable as a single-page "mini flow". A single reference per slot is too rigid for that: a function often needs a different form or payload contract depending on channel, caller or instance state. Workflow states and transitions already solve this with rule-based `views[]`; this brings the same concept to functions.

Nothing has been released against the current shape, so this is **not** a breaking change.

## Reviewer notes

**`scriptCode` is new rather than reused.** `scriptExpression` already exists in this schema but is documented for Dynamic Expresso cache-key expressions. Rules are C# `IConditionMapping` scripts, so this mirrors the *workflow* schema's `scriptCode` instead.

**Two deliberate omissions**, each matching what the runtime component validator rejects:
- `viewRuleEntry` has no `extensions` — a function has no data function to apply them to.
- `schemaRuleEntry` has no `loadData` — a payload contract has no rendering hint.

**Authored against the runtime wire shape, not this repo's `viewDefinition`.** `definitions.viewDefinition` (used by the workflow schema) models rule-based views as `{ rules[], default }`. The runtime's `ViewDefinitionJsonConverter` has **no** `rules`/`default` branch — it expects `views[]` — so anything authored that way deserializes to `null`. That drift is pre-existing; this PR does not propagate it and does not fix it. Worth a separate issue.

## Testing

`test/validate-function-documents.js`, wired into `npm test`.

This repo previously validated only that each `*.schema.json` is itself a valid JSON Schema — which cannot catch a slot that accepts the wrong shape, so a change like this was unverifiable before. The new file validates real function **documents**: 32 cases covering all three shapes × all four slots, plus the rejections (wrong-flow refs, entry missing its `view`/`schema`, empty arrays, `extensions` on a view entry, `loadData` on a schema entry, schema-style entry in a view slot).

```
🎉 All schema files are valid!
🎉 All 32 function documents behaved as expected!
```

## Not included

`schemas/view-definition.schema.json` has an **uncommitted** MDI display-mode rename (`tab`/`window`/`split` → `full-page`/`popup`/`bottom-sheet`/`top-sheet`/`drawer`) in the working tree. It was not authored in this session and is unrelated to function contracts, so it is left out of this PR — it pairs with a matching `ViewEnums.cs` edit in the runtime repo and belongs in its own PR alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support polymorphic view/schema contract slots in function definitions and add document-level validation for their shapes.

New Features:
- Allow function view and schema contract slots to accept single references, rule-based arrays, or wrapped array objects.

Build:
- Extend the npm test script to run both schema validation and function document validation.

Tests:
- Add document-level Ajv-based tests validating all accepted and rejected shapes for function contract slots across multiple cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Function contracts now support flexible schema and view selection, including ordered conditional rules and fallback options.
  * Inline condition scripts and mapping references are supported for contract selection.

* **Bug Fixes**
  * Expanded validation catches invalid, incomplete, unsupported, or incorrectly structured function documents.

* **Tests**
  * Added comprehensive validation coverage for schema and view contracts.
  * Automated tests now include both schema and function-document validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->