### PR TITLE
Update view display mode enum values

### DIFF
--- a/schemas/view-definition.schema.json
+++ b/schemas/view-definition.schema.json
@@ -227,20 +227,28 @@
             "description": "Display mode for MDI (multi-document interface) clients.",
             "oneOf": [
                 {
-                    "const": "tab",
-                    "description": "Opens as a tab in the document area"
+                    "const": "full-page",
+                    "description": "Full page display"
                 },
                 {
-                    "const": "window",
-                    "description": "Opens as a floating/detached window"
+                    "const": "popup",
+                    "description": "Popup/modal display"
                 },
                 {
-                    "const": "split",
-                    "description": "Opens in a split pane next to the active document"
+                    "const": "bottom-sheet",
+                    "description": "Bottom sheet display"
+                },
+                {
+                    "const": "top-sheet",
+                    "description": "Top sheet display"
+                },
+                {
+                    "const": "drawer",
+                    "description": "Drawer/side menu display"
                 },
                 {
                     "const": "inline",
-                    "description": "Inline display within the active document"
+                    "description": "Inline display within page"
                 }
             ]
         },


### PR DESCRIPTION
Replace legacy display mode constants in schemas/view-definition.schema.json with modern UI options (full-page, popup, bottom-sheet, top-sheet, drawer). Also refine the inline description. This aligns the schema with updated client display patterns and clarifies mode semantics.

## Summary by Sourcery

Update view definition schema display mode enumerations to align with modern UI display options and clarify their semantics.

New Features:
- Introduce new display mode options (full-page, popup, bottom-sheet, top-sheet, drawer) in the view definition schema.

Enhancements:
- Refine the inline description of display modes in the view definition schema to better explain their usage and semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new display modes: full-page, popup, bottom-sheet, top-sheet, and drawer.
  * Continued support for inline displays.

* **Updates**
  * Replaced the previous tab, window, and split display options with the new display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->