### PR TITLE
feat(schema): support role-scoped availableIn entries

### DIFF
--- a/docs/components/workflow-definition.md
+++ b/docs/components/workflow-definition.md
@@ -195,8 +195,10 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 **Notes:**
 - Auto (1) is **not supported** -- `triggerType` enum is `[0, 2, 3]`
 - `triggerKind` is **not available** in shared transitions
-- Manual (0): `availableIn` specifies which states this transition applies to
-- Scheduled/Event: `availableIn` must be null (applies globally)
+- Manual (0): `availableIn` specifies which states this transition applies to (see [availableIn](#availablein))
+- Scheduled/Event: `availableIn` must be null (applies globally). Note the base `properties.availableIn`
+  is typed as an array, so in practice a Scheduled/Event shared transition cannot carry `availableIn`
+  in **any** form — including `null`.
 - `additionalProperties` is **not** restricted (open schema)
 
 ---
@@ -237,7 +239,7 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
-| availableIn | string[] | No | No | States where cancel is available; empty/absent = every state (since 0.0.79) |
+| availableIn | availableIn | No | No | States where cancel is available, optionally role-scoped per state; empty/absent = every state (string[] since 0.0.79, object form since 0.0.80) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
@@ -262,7 +264,7 @@ Discriminator: `triggerType` (only 0, 2, 3 -- Auto is not supported)
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
-| availableIn | string[] | No | No | States where exit is available; empty/absent = every state (since 0.0.79) |
+| availableIn | availableIn | No | No | States where exit is available, optionally role-scoped per state; empty/absent = every state (string[] since 0.0.79, object form since 0.0.80) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
@@ -292,7 +294,7 @@ was accepted by the schema but never evaluated.
 | view | viewDefinition | No | Yes | Single or rule-based |
 | mapping | scriptCode | No | Yes | Input mapping |
 | onExecutionTasks | onExecuteTask[] | No | No | Tasks during transition |
-| availableIn | string[] | No | No | States where updateData is available; empty/absent = every state (since 0.0.79) |
+| availableIn | availableIn | No | No | States where updateData is available, optionally role-scoped per state; empty/absent = every state (string[] since 0.0.79, object form since 0.0.80) |
 | roles | roleGrant[] | No | No | Authorization roles |
 | from | string | No | No | `^[a-z0-9-]+$` |
 | annotations | object | No | Yes | Key-value metadata (since 0.0.42) |
@@ -534,6 +536,58 @@ Used at workflow, state, and task levels.
 | grant | enum | Yes | `allow`, `deny`. DENY always overrides ALLOW |
 
 `additionalProperties: false`
+
+---
+
+## availableIn
+
+Array restricting which states a transition is offered in. Empty or absent means **every state**.
+
+Each item is **either** a bare state key **or** an `availableInEntry` object, and the two forms may be
+mixed in one array:
+
+```json
+"availableIn": [
+  "review",
+  { "state": "approval", "roles": [ { "role": "backoffice.supervisor", "grant": "allow" } ] }
+]
+```
+
+| Form | Meaning | Since |
+|------|---------|-------|
+| `"review"` (string) | Available in `review`, no role narrowing | 0.0.1 |
+| `{ "state": "review" }` | Identical to the bare string form | 0.0.80 |
+| `{ "state": "review", "roles": [...] }` | Available in `review` **and** only to callers the grants allow | 0.0.80 |
+
+State keys must match `^[a-z0-9-]+$` in both forms.
+
+Supported on `sharedTransition` (Manual only), `cancelTransition`, `exitTransition` and
+`updateDataTransition`. Optional everywhere.
+
+### availableInEntry
+
+| Field | Type | Required | Constraint |
+|-------|------|----------|------------|
+| state | string | Yes | `^[a-z0-9-]+$` |
+| roles | roleGrant[] | No | Applies only in this state |
+
+`additionalProperties: false`
+
+**Role composition is AND.** A transition's own `roles` is the global gate; an entry's `roles` narrows
+it further for that one state. A caller must satisfy **both**. An entry with no `roles` adds no
+narrowing, which is why the bare string form and the object-without-roles form are equivalent and why
+existing definitions are unaffected.
+
+**Where it is enforced:**
+
+| Surface | State | Roles |
+|---------|:-----:|:-----:|
+| State function `availableTransitions` | Yes | Yes |
+| `authorize` function | Yes | Yes |
+| Transition execution (`POST .../transitions/{key}`) | Yes | No |
+
+Execution deliberately gates on state only — role grants describe what a client should be *offered*,
+and no transition type has ever had its roles re-checked at execution.
 
 ---
 

--- a/schemas/workflow-definition.schema.json
+++ b/schemas/workflow-definition.schema.json
@@ -345,6 +345,42 @@
       },
       "additionalProperties": false
     },
+    "availableInEntry": {
+      "type": "object",
+      "required": [
+        "state"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "State key this entry applies to",
+          "pattern": "^[a-z0-9-]+$"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Role grants that apply only while the instance is in this state. Composed with the transition's own roles as an AND: both must allow. Omit or leave empty for no additional narrowing (identical to the bare string form).",
+          "items": {
+            "$ref": "#/definitions/roleGrant"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "availableIn": {
+      "type": "array",
+      "description": "States where this transition is available. Empty or absent means every state. Each item is either a bare state key or an object narrowing that state to a set of role grants; the two forms may be mixed.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          {
+            "$ref": "#/definitions/availableInEntry"
+          }
+        ]
+      }
+    },
     "viewDefinition": {
       "oneOf": [
         {
@@ -1234,11 +1270,7 @@
               "description": "Trigger type for shared transitions: Manual (0), Scheduled (2), Event (3)"
             },
             "availableIn": {
-              "type": "array",
-              "description": "States where this shared transition is available",
-              "items": {
-                "type": "string"
-              }
+              "$ref": "#/definitions/availableIn"
             },
             "roles": {
               "type": "array",
@@ -1410,11 +1442,7 @@
           "then": {
             "properties": {
               "availableIn": {
-                "type": "array",
-                "description": "States where this shared transition is available",
-                "items": {
-                  "type": "string"
-                }
+                "$ref": "#/definitions/availableIn"
               },
               "view": {
                 "$ref": "#/definitions/viewDefinition"
@@ -1613,11 +1641,7 @@
           "description": "Optional mapping definition for cancel transition input data transformation"
         },
         "availableIn": {
-          "type": "array",
-          "description": "States where this cancel transition is available. Empty or absent means every state (same semantics as shared transitions).",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/availableIn"
         },
         "roles": {
           "type": "array",
@@ -1717,11 +1741,7 @@
           "description": "Optional mapping definition for exit transition input data transformation"
         },
         "availableIn": {
-          "type": "array",
-          "description": "States where this exit transition is available. Empty or absent means every state (same semantics as shared transitions).",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/availableIn"
         },
         "roles": {
           "type": "array",
@@ -1821,11 +1841,7 @@
           "description": "Optional mapping definition for update data transition input data transformation"
         },
         "availableIn": {
-          "type": "array",
-          "description": "States where this update data transition is available. Empty or absent means every state (same semantics as shared transitions).",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/availableIn"
         },
         "roles": {
           "type": "array",


### PR DESCRIPTION
## What

`availableIn` accepted only an array of state keys. It now accepts an array whose items are **either** a bare state key **or** an object narrowing that state by role — and the two forms may be mixed in one array:

```json
"availableIn": [
  "review",
  { "state": "approval", "roles": [ { "role": "backoffice.supervisor", "grant": "allow" } ] }
]
```

Two shared definitions are introduced:

- **`availableInEntry`** — `state` required (`^[a-z0-9-]+$`), optional `roles` as `roleGrant[]`, `additionalProperties: false`.
- **`availableIn`** — array of `oneOf[string, availableInEntry]`.

This follows the `oneOf` union already established for `view.attributes.display` (SDI string vs `{ sdi, mdi }` object), so it is a shape the codebase already understands.

## Why

A committee decision to reduce the security surface opened up when `updateData` and `exit` started appearing in the State function's `availableTransitions`. `availableIn` could restrict *where* a transition is offered but not *who* may use it in a given state — the only role control was transition-wide. Per-state narrowing closes that gap.

## Where it is wired

All five previously inlined declarations now `$ref` the shared definition:

| Site | Note |
|---|---|
| `sharedTransition` (base property) | |
| `sharedTransition` `triggerType: 0` then-branch | **Easy to miss** — this branch redeclares `availableIn` inline; skipping it would reject the object form on exactly the manual shared transitions that can use it |
| `cancelTransition` | |
| `exitTransition` | |
| `updateDataTransition` | |

Optional everywhere, as before.

## Compatibility

**Not a breaking change for authored definitions.** An entry with no `roles` is exactly equivalent to the bare string form, so existing arrays validate unchanged. The runtime writes role-less entries back as bare strings, so component JSON round-trips in the shape it was authored.

**One validation tightening**, called out deliberately: the bare-string form now carries the `^[a-z0-9-]+$` pattern it previously lacked. A state key outside that pattern could never have matched a real state — states themselves are constrained to it — so this rejects only values that were already inert. Flagging it because it is technically stricter than before.

## Reviewer notes

- **Role composition is AND**, documented in the schema description and the docs: `transition.roles` is the global gate and an entry's `roles` narrows it for that one state; a caller must satisfy both. Chosen over replace/OR semantics because the intent is to *reduce* reach.
- **Enforcement differs per surface** (documented in the new docs section): State function and `authorize` check state **and** roles; transition execution checks **state only**, because role grants have never been re-checked at execution for any transition type.
- **Pre-existing contradiction left unchanged**: a Scheduled/Event shared transition cannot carry `availableIn` in *any* form — the base property is typed `array` while the else-branch pins it to `null`, so both an array and `null` fail. Verified against `master`; this PR does not alter it. Now documented rather than silently misleading, since the matrix reads as though `null` were valid there. Happy to fix in a follow-up if you'd rather.

## Docs

`docs/components/workflow-definition.md`:
- New `availableIn` / `availableInEntry` reference section: both forms, a since-version table, AND composition, and a per-surface enforcement table.
- The three well-known transition field tables updated to reference the shared type.
- The Scheduled/Event note above.

## Companion runtime change

Lands separately in `burgan-tech/vnext` on the same branch name: `AvailableInEntry` + `AvailableInJsonConverter` (shape inferred on write, so authored JSON round-trips), AND evaluation funnelled through the single `IRoleGrantEvaluator`, `authorize` made state-aware, and the execution-side state gate extended to `cancel`/`updateData`/`exit` (`Transition:100024`).

Merge order does not matter — the schema change is additive, and the runtime accepts both forms regardless.

## Verification

- `npm test` — all schema files valid.
- Ajv (draft 2019) against the real schema, 18 behavioural assertions, all passing:
  - **Accepted**: legacy string array; object form with roles; object form without roles; **mixed** string + object in one array; empty array; the same set on `exitTransition`; `availableIn` absent.
  - **Rejected**: object missing required `state`; unknown sibling inside an entry (`additionalProperties: false` intact); invalid `grant` value; a `roleGrant` carrying an extra `isDeny` property; state key violating the pattern in **both** forms; `availableIn` given as a bare string instead of an array.
  - The three object-form cases were confirmed to **fail** on `master` and pass here, proving the change is what enables them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document role-scoped availableIn entries and align the workflow schema and docs to a shared availableIn/availableInEntry type that supports both string and object forms.

New Features:
- Introduce an availableInEntry object form that allows per-state role scoping in availableIn arrays alongside the existing bare state key form.

Enhancements:
- Refactor workflow transition schemas to use a shared availableIn definition and apply a consistent state key pattern constraint to both string and object forms.
- Clarify sharedTransition behaviour by documenting that Scheduled/Event shared transitions cannot practically use availableIn in any form.

Documentation:
- Add a dedicated availableIn and availableInEntry reference section describing allowed forms, version history, and enforcement semantics across surfaces.
- Update cancel, exit, and updateData transition field tables to reference the new availableIn type and to describe optional per-state role scoping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded workflow transition availability rules to support state-specific access with optional role grants.
  - Applied shared availability definitions across manual, cancel, exit, and update-data transitions.
  - Added validation for supported state keys and role-based availability behavior.

- **Documentation**
  - Clarified how availability settings work across transition types, including limitations for scheduled and event transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->